### PR TITLE
Add two argument op statement for example code 

### DIFF
--- a/src/test/resources/unittests/regression/nested_constructors/signatures.mark
+++ b/src/test/resources/unittests/regression/nested_constructors/signatures.mark
@@ -29,6 +29,7 @@ entity Botan.PK_Verifier {
 
 	op create {
 	    // C++
+	    Botan::PK_Verifier(pub_key, emsa);
 		Botan::PK_Verifier(pub_key, emsa, ...); // additional params: Signature_Format format=IEEE_1363, const std::string &provider=""
 
         // Fake Java


### PR DESCRIPTION
Adds a two argument op statement to the MARK file to match signature in C++ code.