### PR TITLE
Add a MARK example for OpenSSL EVP

### DIFF
--- a/src/test/java/de/fraunhofer/aisec/crymlin/OpenSSLTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/OpenSSLTest.java
@@ -1,0 +1,33 @@
+
+package de.fraunhofer.aisec.crymlin;
+
+import de.fraunhofer.aisec.analysis.structures.Finding;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OpenSSLTest extends AbstractMarkTest {
+
+	@Disabled
+	@Test
+	// Currently broken because of multiple entities in rule order statement
+	public void testSimple() throws Exception {
+		// Just a very simple test of a source file found in the wild.
+		Set<Finding> findings = performTest("openssl/github.com/DaniloVlad/OpenSSL-AES/aes.c", "openssl/github.com/DaniloVlad/OpenSSL-AES/mark");
+
+		for (Finding f : findings) {
+			System.out.println("  ->" + f.getOnfailIdentifier() + " " + f.getRegions().get(0) + " " + f.getLogMsg());
+		}
+
+		// We expect three (positive) verification of the algorithm used
+		// Set<Finding> _specificFinding = findings.stream()
+		//     .filter(f -> f.getOnfailIdentifier().equals("The_onfail_Identifier"))
+		//     .collect(Collectors.toSet());
+		// assertEquals(-1, wrongAlgorithmsFindings.size()); // expected number of findings
+		// assertEquals(-1, wrongAlgorithmsFindings.stream().filter(Finding::isProblem).collect(Collectors.toSet()).size()); // expected number of actual problems
+	}
+}

--- a/src/test/java/de/fraunhofer/aisec/crymlin/WpdsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/WpdsTest.java
@@ -308,4 +308,51 @@ class WpdsTest extends AbstractMarkTest {
 		assertTrue(startLineNumbers.containsKey(30));
 		assertTrue(startLineNumbers.get(30)); // isProblem
 	}
+
+	@Test
+	void testWpdsOpensslSimplified() throws Exception {
+		@NonNull
+		Set<Finding> findings = performTest("openssl/github.com/DaniloVlad/OpenSSL-AES/aes-simplified.c", "openssl/github.com/DaniloVlad/OpenSSL-AES/mark");
+
+		// Extract <line nr, isProblem> from findings
+		Map<Integer, Boolean> startLineNumbers = findings.stream()
+				.collect(Collectors.toMap(
+					f -> f.getRegions().get(0).getStartLine(),
+					f -> f.isProblem(),
+					(isProblemA, isProblemB) -> {
+						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
+						return isProblemA && isProblemB;
+					}));
+
+		// Note that line numbers of the "range" are the actual line numbers -1. This is required for proper LSP->editor mapping
+		assertFalse(startLineNumbers.get(10)); // EVP_CIPHER_CTX_new
+		assertFalse(startLineNumbers.get(12)); // EVP_EncryptInit
+		assertFalse(startLineNumbers.get(15)); // EVP_EncryptUpdate
+		assertFalse(startLineNumbers.get(18)); // EVP_EncryptFinal
+	}
+
+	@Test
+	void testWpdsOpenssl() throws Exception {
+		@NonNull
+		Set<Finding> findings = performTest("openssl/github.com/DaniloVlad/OpenSSL-AES/aes.c", "openssl/github.com/DaniloVlad/OpenSSL-AES/mark");
+
+		// Extract <line nr, isProblem> from findings
+		Map<Integer, Boolean> startLineNumbers = findings.stream()
+				.collect(Collectors.toMap(
+					f -> f.getRegions().get(0).getStartLine(),
+					f -> f.isProblem(),
+					(isProblemA, isProblemB) -> {
+						if (isProblemA != isProblemB) {
+							System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
+						}
+						return isProblemA && isProblemB;
+					}));
+
+		// Note that line numbers of the "range" are the actual line numbers -1. This is required for proper LSP->editor mapping
+		assertFalse(startLineNumbers.get(11)); // EVP_CIPHER_CTX_new
+		assertFalse(startLineNumbers.get(13)); // EVP_EncryptInit
+		assertFalse(startLineNumbers.get(16)); // EVP_EncryptUpdate
+		assertFalse(startLineNumbers.get(19)); // EVP_EncryptFinal
+	}
+
 }

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/.gitignore
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/.gitignore
@@ -1,0 +1,2 @@
+main
+.vscode/

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/README.md
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/README.md
@@ -1,0 +1,100 @@
+# OpenSSL-AES
+
+An example of using OpenSSL EVP Interface for Advanced Encryption Standard (AES) in cipher block chaining mode (CBC) with 256 bit keys.
+For more information visit the [OpenSSL docs](https://www.openssl.org/docs/manmaster/)
+
+## Usage
+Compile the code with:
+```
+root@server:~$ make
+gcc main.c -g -Wall -lcrypto aes.c -o main
+```
+
+## Reason
+I saw loads of questions on stackoverflow on how to implement a simple aes256 example. So here it is! AES-256 is just a subset of the Rijndael block ciphers.  Block ciphers operate on fixed sized matrices called "blocks". For AES these blocks are 4x4 matrices and each element is 1 byte (Hence 16 byte "block size").  Any message not a multiple of the block size will be extended to fill the space.  This is the default behavoir for the EVP_ENCRYPTFINAL_ex functions.
+ie: 12 chars becomes 16 chars, 22 chars becomes 32 chars.  
+```C
+int enc_length = *(plaintext -> length) + (AES_BLOCK_SIZE - *(plaintext -> length) % AES_BLOCK_SIZE);
+```
+
+## Sample Output
+```
+root@server:~$ make
+gcc main.c -g -Wall -lcrypto aes.c -o main
+root@server:~$ ./main
+Enter a message up to 1024 chars: 
+Hello World! My name is Danilo and I love you!
+Key:
+
+9A 24 EB 27 
+BB FE 4B 78 
+66 10 0A 26 
+9F 41 A8 F1 
+AC 00 F0 1C 
+40 4E BB 2C 
+B9 A7 18 4E 
+2B 18 E4 C7 
+
+IV:
+
+2F 2F 66 EC 
+F0 EE B0 FB 
+1E 80 77 06 
+94 FB A2 BB 
+35 82 A9 C0 
+E5 3F 59 19 
+B5 F5 EE ED 
+E4 A6 16 A8 
+
+User Message:
+
+48 65 6C 6C 
+6F 20 57 6F 
+72 6C 64 21 
+20 4D 79 20 
+6E 61 6D 65 
+20 69 73 20 
+44 61 6E 69 
+6C 6F 20 61 
+6E 64 20 49 
+20 6C 6F 76 
+65 20 79 6F 
+75 21 0A 
+
+Hello World! My name is Danilo and I love you!
+
+Sending message to be encrypted...
+Encrypted Message:
+
+EF 6C 0F E6 
+13 1C E0 CC 
+E7 5B 46 FE 
+A5 20 F4 F9 
+C2 06 61 4C 
+A6 43 81 3F 
+CE 81 01 C1 
+8C 50 60 DC 
+E3 B2 89 CF 
+46 A7 C8 FE 
+03 4F DD E1 
+11 C2 1C 58 
+
+Sending message to be decrypted...
+Decrypted Message:
+
+48 65 6C 6C 
+6F 20 57 6F 
+72 6C 64 21 
+20 4D 79 20 
+6E 61 6D 65 
+20 69 73 20 
+44 61 6E 69 
+6C 6F 20 61 
+6E 64 20 49 
+20 6C 6F 76 
+65 20 79 6F 
+75 21 0A 
+
+Hello World! My name is Danilo and I love you!
+
+```

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/aes-simplified.c
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/aes-simplified.c
@@ -1,0 +1,28 @@
+#include "includes/aes.h"
+
+Message *aes256_encrypt(Message * plaintext) {
+    EVP_CIPHER_CTX *enc_ctx;
+    Message * encrypted_message;
+    int enc_length = 42;
+
+    encrypted_message = message_init(enc_length);
+
+    //set up encryption context
+    enc_ctx = EVP_CIPHER_CTX_new();
+
+    EVP_EncryptInit(enc_ctx, EVP_aes_256_cbc(), plaintext -> aes_settings -> key, plaintext -> aes_settings -> iv);
+
+    //encrypt all the bytes up to but not including the last block
+    EVP_EncryptUpdate(enc_ctx, encrypted_message -> body, &enc_length, plaintext -> body, *plaintext -> length);
+
+    //EncryptFinal will cipher the last block + Padding
+    EVP_EncryptFinal_ex(enc_ctx, enc_length + encrypted_message -> body, &enc_length);
+
+    //add padding to length
+    *(encrypted_message -> length) += enc_length;
+
+    //Free context and return encrypted message
+    EVP_CIPHER_CTX_cleanup(enc_ctx);
+
+    return encrypted_message;
+}

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/aes.c
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/aes.c
@@ -1,0 +1,110 @@
+#include "includes/aes.h"
+
+Message * message_init(int length) {
+    Message *ret = malloc(sizeof(Message));
+    ret -> body = malloc(length);
+    ret -> length = malloc(sizeof(int));
+    *ret -> length = length;
+    //used string terminator to allow string methods to work
+    memset(ret -> body, '\0', length);
+    //initialize aes_data
+    aes256_init(ret);
+    return ret;
+}
+
+int aes256_init(Message * input) {
+    AES_DATA *aes_info = malloc(sizeof(AES_DATA));
+    aes_info -> key = malloc(sizeof(char) * AES_KEY_SIZE);
+    aes_info -> iv = malloc(sizeof(char) * AES_KEY_SIZE);
+    //point to new data
+    input -> aes_settings = aes_info;
+    //set to zero
+    memset(input -> aes_settings -> key, 0, AES_KEY_SIZE);
+    memset(input -> aes_settings -> iv, 0, AES_KEY_SIZE);
+    //get rand bytes
+    if(!RAND_bytes(input -> aes_settings -> key, AES_KEY_SIZE) || !RAND_bytes(input -> aes_settings -> iv, AES_KEY_SIZE)) {
+        printf("Error: couldn't generate key or iv!");
+        return 1;
+    }
+    return 0;
+}
+
+Message *aes256_encrypt(Message * plaintext) {
+    EVP_CIPHER_CTX *enc_ctx;
+    Message * encrypted_message;
+    int enc_length = *(plaintext -> length) + (AES_BLOCK_SIZE - *(plaintext -> length) % AES_BLOCK_SIZE);
+
+    encrypted_message = message_init(enc_length);
+    //set up encryption context
+    enc_ctx = EVP_CIPHER_CTX_new();
+    EVP_EncryptInit(enc_ctx, EVP_aes_256_cbc(), plaintext -> aes_settings -> key, plaintext -> aes_settings -> iv);
+    //encrypt all the bytes up to but not including the last block
+    if(!EVP_EncryptUpdate(enc_ctx, encrypted_message -> body, &enc_length, plaintext -> body, *plaintext -> length)) {
+        EVP_CIPHER_CTX_cleanup(enc_ctx);
+        printf("EVP Error: couldn't update encryption with plain text!\n");
+        return NULL;
+    }
+    //update length with the amount of bytes written
+    *(encrypted_message -> length) = enc_length;
+    //EncryptFinal will cipher the last block + Padding
+    if(!EVP_EncryptFinal_ex(enc_ctx, enc_length + encrypted_message -> body, &enc_length)) {
+        EVP_CIPHER_CTX_cleanup(enc_ctx);
+        printf("EVP Error: couldn't finalize encryption!\n");
+        return NULL;
+    }
+    //add padding to length
+    *(encrypted_message -> length) += enc_length;
+    //no errors, copy over key & iv rather than pointing to the plaintext msg
+    memcpy(encrypted_message -> aes_settings -> key, plaintext -> aes_settings -> key, AES_KEY_SIZE);
+    memcpy(encrypted_message -> aes_settings -> iv, plaintext -> aes_settings -> iv, AES_KEY_SIZE);
+    //Free context and return encrypted message
+    EVP_CIPHER_CTX_cleanup(enc_ctx);
+    return encrypted_message;
+}
+
+Message *aes256_decrypt(Message *encrypted_message) {
+    EVP_CIPHER_CTX *dec_ctx;
+    int dec_length = 0;
+    Message * decrypted_message;
+    //initialize return message and cipher context
+    decrypted_message = message_init(*encrypted_message -> length);
+    dec_ctx = EVP_CIPHER_CTX_new();
+    EVP_DecryptInit(dec_ctx, EVP_aes_256_cbc(), encrypted_message -> aes_settings -> key, encrypted_message -> aes_settings -> iv);
+    //same as above
+    if(!EVP_DecryptUpdate(dec_ctx, decrypted_message -> body, &dec_length, encrypted_message -> body, *encrypted_message -> length)) {
+        EVP_CIPHER_CTX_cleanup(dec_ctx);
+        printf("EVP Error: couldn't update decrypt with text!\n");
+        return NULL;
+    }  
+    *(decrypted_message -> length) = dec_length;
+    if(!EVP_DecryptFinal_ex(dec_ctx, *decrypted_message->length + decrypted_message -> body, &dec_length)) {
+        EVP_CIPHER_CTX_cleanup(dec_ctx);
+        printf("EVP Error: couldn't finalize decryption!\n");
+        return NULL;
+    }
+    //auto handle padding
+    *(decrypted_message -> length) += dec_length;
+    //Terminate string for easier use.
+    *(decrypted_message -> body + *decrypted_message -> length) = '\0';
+    //no errors, copy over key & iv rather than pointing to the encrypted msg
+    memcpy(decrypted_message -> aes_settings -> key, encrypted_message -> aes_settings -> key, AES_KEY_SIZE);
+    memcpy(decrypted_message -> aes_settings -> iv, encrypted_message -> aes_settings -> iv, AES_KEY_SIZE);
+    //free context and return decrypted message
+    EVP_CIPHER_CTX_cleanup(dec_ctx);
+    return decrypted_message;
+}
+
+void aes_cleanup(AES_DATA *aes_data) {
+    free(aes_data -> iv);
+    free(aes_data -> key);
+    free(aes_data);
+}
+
+void message_cleanup(Message *message) {
+    //free message struct
+    aes_cleanup(message -> aes_settings);
+    free(message -> length);
+    free(message -> body);
+    free(message);
+}
+

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/includes/aes.h
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/includes/aes.h
@@ -1,0 +1,41 @@
+#ifndef AES_H_
+#define AES_H_
+
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/conf.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+
+#define AES_BLOCK_SIZE 16
+#define AES_KEY_SIZE 32
+
+typedef struct _AES_DATA 
+{
+    unsigned char *key;
+    unsigned char *iv;
+} AES_DATA;
+
+typedef struct Message_Struct
+{
+    unsigned char *body;
+    int *length;
+    AES_DATA *aes_settings;
+    
+} Message;
+
+Message *message_init(int);
+
+int aes256_init(Message *);
+
+Message *aes256_encrypt(Message *);
+
+Message *aes256_decrypt(Message *);
+
+void aes_cleanup(AES_DATA *);
+void message_cleanup(Message *);
+
+
+
+#endif

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/main.c
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/main.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include "includes/aes.h"
+
+void hex_print(unsigned char *in, size_t len) {
+    for(int i = 0; i < len; i++) {
+        if(i % 4 == 0)
+            printf("\n");
+        printf("%02X ", *(in + i));
+    }
+    printf("\n\n");
+}
+
+int main() {
+    // Initialize openSSL
+    ERR_load_crypto_strings();
+    OpenSSL_add_all_algorithms();
+    OPENSSL_config(NULL);
+
+    
+    //input buffer, the AES alg (Rijndael) works on blocks of 16 bytes in a 4x4
+    //If a string is 12 chars (bytes) it gets padded to 16.
+    char input[1024] = {0};
+   //create & init message pointer 
+    Message *message, *enc_msg, *dec_msg;
+
+    //get message to be encrypted
+    printf("Enter a message up to 1024 chars: \n");
+    fgets(input, 1024, stdin);
+
+    message = message_init(strlen(input));
+    strcpy((char *) message -> body, input);
+
+    if(aes256_init(message)) {
+        puts("Error: Couldn't initialize message with aes data!");
+        return 1;
+    }
+
+    puts("Key:");
+    hex_print(message -> aes_settings -> key, AES_KEY_SIZE);
+
+    puts("IV:");
+    hex_print(message -> aes_settings -> iv, AES_KEY_SIZE);
+
+    puts("User Message:");
+    hex_print(message -> body, *message -> length);
+    puts((char *) message -> body);
+    puts("Sending message to be encrypted...");
+    enc_msg = aes256_encrypt(message);
+
+    puts("Encrypted Message:");
+    hex_print(enc_msg -> body, *enc_msg -> length);
+
+    puts("Sending message to be decrypted...");
+    dec_msg = aes256_decrypt(enc_msg);
+
+    puts("Decrypted Message:");
+    hex_print(dec_msg -> body, *dec_msg -> length);
+    puts((char *) dec_msg -> body);
+    //destroy messages
+    message_cleanup(message);
+    message_cleanup(enc_msg);
+    message_cleanup(dec_msg);
+    //clean up ssl;
+    EVP_cleanup(); 
+    CRYPTO_cleanup_all_ex_data(); //Stop data leaks
+    ERR_free_strings();
+
+    return 0;
+}

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/makefile
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/makefile
@@ -1,0 +1,11 @@
+# the compiler
+CC = gcc
+
+# compiler flags
+CFLAGS  = -g -Wall -lcrypto
+
+main: main.c aes.c
+	$(CC) main.c $(CFLAGS) aes.c -o main
+
+clean:
+	$(RM) main

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp-rules.mark
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp-rules.mark
@@ -1,0 +1,30 @@
+package openssl.evp.rules
+
+rule AESwithCBC {
+	using
+		OpenSSL.EVP_Encrypt as enc,
+		AES128_CBC as aes128cbc,
+		AES192_CBC as aes192cbc,
+		AES256_CBC as aes256cbc
+	ensure
+		_is(enc.type, aes128cbc)
+		|| _is(enc.type, aes192cbc)
+		|| _is(enc.type, aes256cbc)
+	onfail
+		NoAESwithCBC
+}
+
+rule EVP_Encrypt_Order {
+	using
+		OpenSSL.EVP_Encrypt as enc
+	ensure
+		order 
+			enc.create(), 
+			(
+				enc.update()*, 
+				enc.finalize()
+			)?, 
+			enc.cleanup()
+	onfail
+		WrongEVP_EncryptOrder
+}

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp-rules.mark
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp-rules.mark
@@ -16,15 +16,15 @@ rule AESwithCBC {
 
 rule EVP_Encrypt_Order {
 	using
-		OpenSSL.EVP_Encrypt as enc
+		OpenSSL.EVP_Encrypt as enc,
+		EVP_Cipher_Ctx as ctx
 	ensure
-		order 
-			enc.create(), 
-			(
-				enc.update()*, 
-				enc.finalize()
-			)?, 
-			enc.cleanup()
+		order
+		    ctx.create(),
+			enc.init(),
+			enc.update()*,
+			enc.finalize()?,
+			ctx.cleanup()
 	onfail
 		WrongEVP_EncryptOrder
 }

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp.mark
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp.mark
@@ -1,8 +1,24 @@
 package openssl.evp
 
+entity EVP_Cipher_Ctx {
+
+    var ctx;
+
+    op create {
+        ctx = EVP_CIPHER_CTX_new();
+    }
+
+	op cleanup {
+		EVP_CIPHER_CTX_cleanup(
+			ctx
+		);
+	}
+
+}
+
 entity OpenSSL.EVP_Encrypt {
 	
-	var ctx;
+	var ctx : EVP_Cipher_Ctx;
 	var type;
 	var key;
 	var iv;
@@ -12,11 +28,7 @@ entity OpenSSL.EVP_Encrypt {
 	var pt_in;
 	var pt_inl;
 	
-	
-	op create {
-		ctx = EVP_CIPHER_CTX_new();
-	}
-	
+
 	op init {
 		EVP_EncryptInit(
 			ctx, 
@@ -43,10 +55,5 @@ entity OpenSSL.EVP_Encrypt {
 			ct_outl
 		);
 	}
-	
-	op cleanup {
-		EVP_CIPHER_CTX_cleanup(
-			ctx
-		);
-	}
+
 }

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp.mark
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl-evp.mark
@@ -1,0 +1,52 @@
+package openssl.evp
+
+entity OpenSSL.EVP_Encrypt {
+	
+	var ctx;
+	var type;
+	var key;
+	var iv;
+	
+	var ct_out;
+	var ct_outl;
+	var pt_in;
+	var pt_inl;
+	
+	
+	op create {
+		ctx = EVP_CIPHER_CTX_new();
+	}
+	
+	op init {
+		EVP_EncryptInit(
+			ctx, 
+			type, 
+			key, 
+			iv
+		);
+	}
+	
+	op update {
+		EVP_EncryptUpdate(
+			ctx, 
+			ct_out, 
+			ct_outl, 
+			pt_in, 
+			pt_inl
+		);
+	}
+	
+	op finalize {
+		EVP_EncryptFinal_ex(
+			ctx, 
+			ct_out, 
+			ct_outl
+		);
+	}
+	
+	op cleanup {
+		EVP_CIPHER_CTX_cleanup(
+			ctx
+		);
+	}
+}

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl.mark
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/openssl.mark
@@ -1,0 +1,5 @@
+package openssl
+
+entity OpenSSL {
+	
+}

--- a/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/opensslevp-cipher.mark
+++ b/src/test/resources/openssl/github.com/DaniloVlad/OpenSSL-AES/mark/opensslevp-cipher.mark
@@ -1,0 +1,35 @@
+package openssl.evp.cipher
+
+entity AES128_CBC {
+	
+	var evp_cipher;
+	
+	
+	op init {
+		evp_cipher = EVP_aes_128_cbc();
+	}
+	
+}
+
+entity AES192_CBC {
+	
+	var evp_cipher;
+	
+	
+	op init {
+		evp_cipher = EVP_aes_192_cbc();
+	}
+	
+}
+
+entity AES256_CBC {
+	
+	var evp_cipher;
+	
+	
+	op init {
+		evp_cipher = EVP_aes_256_cbc();
+	}
+	
+}
+


### PR DESCRIPTION
This PR will add: 
- an OpenSSL encryption/decryption example using AES256 in CBC mode from [DaniloVlad/OpenSSL-AES](https://github.com/DaniloVlad/OpenSSL-AES)
- corresponding MARK entities and rules to verify the use of OpenSSL EVP

This currently does not work. `EVP_CIPHER_CTX` and `EVP_Encrypt*` are seperated into two entities. The resulting order rule defines two entities in the `using` clause. This isn't supported.