### PR TITLE
Crymlin console improvements

### DIFF
--- a/docs/content/en/docs/Crymlin Query/_index.md
+++ b/docs/content/en/docs/Crymlin Query/_index.md
@@ -40,20 +40,26 @@ Every query must begin with a traversal *source* which retrieves an initial iter
 
 | Traversal Source | Description |
 |---|---|
-|  `.byID(int id)`  | Node with the give id. The id of a node can be retrieved by the `.id()` step. |
-|  `.calls()`  | Calls to methods or functions (`CallExpression`) |
-|  `.calls(String calleeName)`  | Calls to methods or functions matching this name (`CallExpression`) |
+|  `.allCalls()`  | All function/method calls) |
+|  `.byID(int id)`  | Node with the given ID. The ID of a node can be retrieved by the `.id()` step. |
+|  `.calls(String subString)`  | Calls to functions/methods (`CallExpression`) whose (fully qualified) name _contains_ the argument. |
+|  `.callsFqn(String fqn)`  | Calls to functions/methods (`CallExpression`) whose (fully qualified) name _matches exactly_ the argument. |
 |  `.ctor(String type)`  | Constructors of the given fully qualified type (`ConstructExpression`) |
 |  `.declarations()`  | All declarations (of fields, variables, records, etc. (any of `FieldDeclaration`, `VariableDeclaration`, `RecordDeclaration`, etc.) |
 |  `.fields()`  |  Declarations of fields (`FieldDeclaration`) |
 |  `.field(String fieldName)`  |  Declarations of fields with the given name (`FieldDeclaration`) |
-|  `.functions()`  | Class methods and functions (`FunctionDeclaration`) |
+|  `.functiondeclaration(String subString)`  | Class methods and functions (`FunctionDeclaration`) whose name _contains_ the argument |
+|  `.functiondeclarations()`  | All class methods and functions (`FunctionDeclaration`) |
 |  `.methods()`  | Class methods (`MethodDeclaration`) |
+|  `.namespaces()`  | Namespace declarations (`NamespaceDeclaration`) |
 |  `.records()`  | Records are classes, enums, structs (`RecordDeclaration`) |
 |  `.records(String name)`  | Records such as classes, enums, structs that match the given name (`RecordDeclaration`) |
+|  `.statements()`  | All statements (`Statement`) |
 |  `.translationunits()`  | File names of matching source code (`TranslationUnit`) |
 |  `.vars()`  | Declarations of variables (`VariableDeclaration`) |
 |  `.V()`  | All nodes in the graph |
+
+
 
 
 ### Traversal Steps

--- a/src/main/java/de/fraunhofer/aisec/analysis/CandidateListCompletionHandler.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/CandidateListCompletionHandler.java
@@ -91,15 +91,15 @@ public class CandidateListCompletionHandler implements CompletionHandler {
 
 			String noOpt = Messages.DISPLAY_CANDIDATES_NO.format();
 			String yesOpt = Messages.DISPLAY_CANDIDATES_YES.format();
-			char[] allowed = { yesOpt.charAt(0), noOpt.charAt(0) };
+			char[] allowed = { yesOpt.toLowerCase().charAt(0), yesOpt.toUpperCase().charAt(0), noOpt.toLowerCase().charAt(0), noOpt.toUpperCase().charAt(0) };
 
 			while ((c = reader.readCharacter(allowed)) != -1) {
 				String tmp = new String(new char[] { (char) c });
 
-				if (noOpt.startsWith(tmp)) {
+				if (noOpt.toUpperCase().startsWith(tmp.toUpperCase())) {
 					reader.println();
 					return;
-				} else if (yesOpt.startsWith(tmp)) {
+				} else if (yesOpt.toUpperCase().startsWith(tmp.toUpperCase())) {
 					break;
 				} else {
 					reader.beep();
@@ -169,17 +169,17 @@ public class CandidateListCompletionHandler implements CompletionHandler {
 }
 
 enum Messages {
-	DISPLAY_CANDIDATES,
-	DISPLAY_CANDIDATES_YES,
-	DISPLAY_CANDIDATES_NO,
+	DISPLAY_CANDIDATES("Display all methods? (Y/N)"),
+	DISPLAY_CANDIDATES_YES("y"),
+	DISPLAY_CANDIDATES_NO("n"),
 	;
 
-	private static final ResourceBundle bundle = ResourceBundle.getBundle(CandidateListCompletionHandler.class.getName(), Locale.getDefault());
+	String msg;
+	Messages(String msg) {
+		this.msg = msg;
+	}
 
 	public String format(final Object... args) {
-		if (bundle == null)
-			return "";
-		else
-			return String.format(bundle.getString(name()), args);
+		return String.format(this.msg, args);
 	}
 }

--- a/src/main/java/de/fraunhofer/aisec/analysis/Commands.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/Commands.java
@@ -211,11 +211,11 @@ public class Commands {
 
 	private static void printQueryTerminators() {
 		StringBuilder sbEntry = new StringBuilder();
-		sbEntry.append(String.format("%-38s - %s\n", "toList()", "Collect results in a list"));
-		sbEntry.append(String.format("%-38s - %s\n", "toSet()", "Collect results in a set (removing duplicates)"));
-		sbEntry.append(String.format("%-38s - %s\n", "next()",
+		sbEntry.append(String.format("%-38s - %s%n", "toList()", "Collect results in a list"));
+		sbEntry.append(String.format("%-38s - %s%n", "toSet()", "Collect results in a set (removing duplicates)"));
+		sbEntry.append(String.format("%-38s - %s%n", "next()",
 			"Return one result. The returned result is non-deterministically selected. If the result set is empty, an error will be thrown"));
-		sbEntry.append(String.format("%-38s - %s\n", "tryNext()",
+		sbEntry.append(String.format("%-38s - %s%n", "tryNext()",
 			"Returns an \"Optional\" of one result. The returned result is non-deterministically selected. If the result set is empty, the Optional is empty"));
 		System.out.println(sbEntry);
 	}

--- a/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
@@ -64,7 +64,7 @@ public class JythonInterpreter implements AutoCloseable {
 	 * gremlin-jython engine. We use an interpreted language like Python (or Groovy) so we can easily evaluate Crymlin queries that are entered by the user at runtime and
 	 * handled as mere strings.
 	 */
-	final ScriptEngine engine = new DefaultGremlinScriptEngineManager().getEngineByName("gremlin-jython");
+	final ScriptEngine engine = new ScriptEngineManager().getEngineByName("jython");
 
 	// store last result
 	private TranslationResult lastTranslationResult = null;

--- a/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
@@ -5,7 +5,6 @@ import de.fraunhofer.aisec.analysis.structures.Finding;
 import de.fraunhofer.aisec.analysis.utils.Utils;
 import de.fraunhofer.aisec.cpg.TranslationResult;
 import de.fraunhofer.aisec.crymlin.connectors.db.TraversalConnection;
-import org.apache.tinkerpop.gremlin.jsr223.DefaultGremlinScriptEngineManager;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.python.core.Py;

--- a/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
@@ -55,6 +55,7 @@ public class JythonInterpreter implements AutoCloseable {
 	public static final String PY_S = "s";
 	public static final String PY_QUERY = "query";
 	public static final String PY_Q = "q";
+	public static final String PY_HELP = "help()";
 
 	/** connection to the database via a traversal */
 	private TraversalConnection traversalConnection = null;
@@ -86,7 +87,7 @@ public class JythonInterpreter implements AutoCloseable {
 		bindings.put(PY_QUERY, traversalConnection.getCrymlinTraversal()); // Trav. source of crymlin
 		bindings.put(PY_Q, traversalConnection.getCrymlinTraversal()); // Trav. source of crymlin
 
-		// If we aready have a running console, update bound objects
+		// If we already have a running console, update bound objects
 		if (this.c != null) {
 			for (Map.Entry<String, Object> kv : this.engine.getBindings(ScriptContext.ENGINE_SCOPE)
 					.entrySet()) {

--- a/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
@@ -268,12 +268,7 @@ public class JythonInterpreter implements AutoCloseable {
 			List<String> items = new ArrayList<>();
 			try {
 				if (dotPos > -1) {
-					try {
-						items = (List<String>) engine.eval("dir(" + withoutDot.strip() + ")");
-					}
-					catch (Exception e) {
-						e.printStackTrace();
-					}
+					items = (List<String>) engine.eval("dir(" + withoutDot.strip() + ")");
 				} else {
 					items = List.of(PY_HELP, PY_QUERY, PY_Q, PY_SERVER, PY_S, PY_GRAPH, PY_G);
 				}

--- a/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/JythonInterpreter.java
@@ -13,10 +13,7 @@ import org.python.core.PyMethod;
 import org.python.jline.console.completer.Completer;
 import org.python.util.JLineConsole;
 
-import javax.script.Bindings;
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
+import javax.script.*;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -269,12 +266,17 @@ public class JythonInterpreter implements AutoCloseable {
 		private void fillPythonSuggestions(String s, int dotPos, List<CharSequence> list) {
 			String withoutDot = dotPos > -1 ? s.substring(0, dotPos) : s;
 			String prefix = dotPos > -1 && dotPos < s.length() - 1 ? s.substring(dotPos + 1).strip() : "";
-			List<String> items;
+			List<String> items = new ArrayList<>();
 			try {
 				if (dotPos > -1) {
-					items = (List<String>) engine.eval("dir(" + withoutDot + ")");
+					try {
+						items = (List<String>) engine.eval("dir(" + withoutDot.strip() + ")");
+					}
+					catch (Exception e) {
+						e.printStackTrace();
+					}
 				} else {
-					items = List.of(PY_QUERY, PY_Q, PY_SERVER, PY_S, PY_GRAPH, PY_G);
+					items = List.of(PY_HELP, PY_QUERY, PY_Q, PY_SERVER, PY_S, PY_GRAPH, PY_G);
 				}
 
 				for (String str : items) {

--- a/src/main/java/de/fraunhofer/aisec/analysis/utils/Utils.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/utils/Utils.java
@@ -277,13 +277,11 @@ public class Utils {
 	public static List<Method> getMethodsAnnotatedWith(final Class<?> type, final Class<? extends Annotation> annotation) {
 		final List<Method> methods = new ArrayList<>();
 		Class<?> klass = type;
-		while (klass != Object.class) { // need to iterated thought hierarchy in order to retrieve methods from above the current instance
+		while (klass != null && klass != Object.class) { // need to iterated thought hierarchy in order to retrieve methods from above the current instance
 			// iterate though the list of methods declared in the class represented by class variable, and add those annotated with the specified annotation
 			final List<Method> allMethods = new ArrayList<>(Arrays.asList(klass.getDeclaredMethods()));
 			for (final Method method : allMethods) {
 				if (method.isAnnotationPresent(annotation)) {
-					// TODO process annotInstance
-					//Annotation annotInstance = method.getAnnotation(annotation);
 					methods.add(method);
 				}
 			}

--- a/src/main/java/de/fraunhofer/aisec/crymlin/CrymlinQueryWrapper.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/CrymlinQueryWrapper.java
@@ -112,7 +112,7 @@ public class CrymlinQueryWrapper {
 		fqnName = Utils.unifyType(fqnName);
 
 		// since fqn is a fully qualified name, this includes method calls on an instance, static calls, and functioncalls
-		Set<Vertex> ret = new HashSet<>(crymlinTraversal.calls(fqnName).toSet());
+		Set<Vertex> ret = new HashSet<>(crymlinTraversal.callsFqn(fqnName).toSet());
 
 		// now, ret contains possible candidates --> need to filter out calls where params don't match
 		ret.removeIf(

--- a/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalDsl.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalDsl.java
@@ -1,14 +1,21 @@
 
 package de.fraunhofer.aisec.crymlin.dsl;
 
+import de.fraunhofer.aisec.analysis.ShellCommand;
 import de.fraunhofer.aisec.cpg.graph.BinaryOperator;
 import de.fraunhofer.aisec.cpg.graph.Literal;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import org.apache.tinkerpop.gremlin.neo4j.process.traversal.LabelP;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDsl;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.regex.Matcher;
 
 /**
  * this class adds new Traversal-Steps
@@ -62,6 +69,7 @@ public interface CrymlinTraversalDsl<S, E> extends GraphTraversal.Admin<S, E> {
 	 */
 	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Object" }, // c/p from example, unclear.
 			methodTypeParameters = { "A" })
+	@ShellCommand("Name of the selected node(s) (as a string)")
 	default CrymlinTraversal<S, Object> name() {
 		return (CrymlinTraversal<S, Object>) values("name");
 	}
@@ -84,6 +92,7 @@ public interface CrymlinTraversalDsl<S, E> extends GraphTraversal.Admin<S, E> {
 	 */
 	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Object" }, // c/p from example, unclear.
 			methodTypeParameters = { "A" })
+	@ShellCommand("Comments attached to the selected node(s) (as a string)")
 	default CrymlinTraversal<S, Object> comment() {
 		return (CrymlinTraversal<S, Object>) values("comment");
 	}
@@ -95,6 +104,7 @@ public interface CrymlinTraversalDsl<S, E> extends GraphTraversal.Admin<S, E> {
 	 */
 	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Object" }, // c/p from example, unclear.
 			methodTypeParameters = { "A" })
+	@ShellCommand("Original source code of the selected node(s) (as a string)")
 	default CrymlinTraversal<S, Object> code() {
 		return (CrymlinTraversal<S, Object>) values("code");
 	}
@@ -105,8 +115,42 @@ public interface CrymlinTraversalDsl<S, E> extends GraphTraversal.Admin<S, E> {
 	 * @return
 	 */
 	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Vertex" }, methodTypeParameters = { "A" })
-	default CrymlinTraversal<S, Vertex> cfg() {
+	@ShellCommand("Next node(s) in Control Flow Graph")
+	default CrymlinTraversal<S, Vertex> nextCfg() {
 		return (CrymlinTraversal<S, Vertex>) out("CFG");
+	}
+
+	/**
+	 * Shortcut for {@code .in("CFG")}.
+	 *
+	 * @return
+	 */
+	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Vertex" }, methodTypeParameters = { "A" })
+	@ShellCommand("Previous node(s) in Control Flow Graph")
+	default CrymlinTraversal<S, Vertex> prevCfg() {
+		return (CrymlinTraversal<S, Vertex>) in("CFG");
+	}
+
+	/**
+	 * Shortcut for {@code .out("EOG")}.
+	 *
+	 * @return
+	 */
+	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Vertex" }, methodTypeParameters = { "A" })
+	@ShellCommand("Next node(s) in Evaluation Order Graph")
+	default CrymlinTraversal<S, Vertex> nextEog() {
+		return (CrymlinTraversal<S, Vertex>) out(CrymlinConstants.EOG);
+	}
+
+	/**
+	 * Shortcut for {@code .in("EOG")}.
+	 *
+	 * @return
+	 */
+	@GremlinDsl.AnonymousMethod(returnTypeParameters = { "A", "Vertex" }, methodTypeParameters = { "A" })
+	@ShellCommand("Previous node(s) in Evaluation Order Graph")
+	default CrymlinTraversal<S, Vertex> prevEog() {
+		return (CrymlinTraversal<S, Vertex>) in(CrymlinConstants.EOG);
 	}
 
 	/**

--- a/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalDsl.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalDsl.java
@@ -6,16 +6,10 @@ import de.fraunhofer.aisec.cpg.graph.BinaryOperator;
 import de.fraunhofer.aisec.cpg.graph.Literal;
 import de.fraunhofer.aisec.cpg.graph.VariableDeclaration;
 import org.apache.tinkerpop.gremlin.neo4j.process.traversal.LabelP;
-import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.GremlinDsl;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
-import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-
-import java.util.regex.Matcher;
 
 /**
  * this class adds new Traversal-Steps

--- a/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalSourceDsl.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalSourceDsl.java
@@ -13,10 +13,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import static de.fraunhofer.aisec.crymlin.dsl.CrymlinConstants.*;
+import static de.fraunhofer.aisec.crymlin.dsl.CrymlinConstants.EOG;
+import static de.fraunhofer.aisec.crymlin.dsl.CrymlinConstants.NAME;
 import static de.fraunhofer.aisec.crymlin.dsl.__.hasLabel;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
-import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
 
 /**
  * This class adds new functions to the traversal to START from
@@ -85,7 +85,7 @@ public class CrymlinTraversalSourceDsl extends GraphTraversalSource {
 	 * @return traversal of matched {@code CallExpression} vertices
 	 */
 	@ShellCommand("Calls to functions/methods whose (fully qualified) name contains the argument.")
-	public GraphTraversal<Vertex, Vertex> calls(String calleeName) {
+	public GraphTraversal<Vertex, Vertex> call(String calleeName) {
 		GraphTraversal<Vertex, Vertex> traversal = this.clone().V();
 
 		return traversal

--- a/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalSourceDsl.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/dsl/CrymlinTraversalSourceDsl.java
@@ -247,7 +247,7 @@ public class CrymlinTraversalSourceDsl extends GraphTraversalSource {
 	 *
 	 * @return
 	 */
-	@ShellCommand("Node from id")
+	@ShellCommand("Node by its ID")
 	public GraphTraversal<Vertex, Vertex> byID(long id) {
 		GraphTraversal<Vertex, Vertex> traversal = this.clone().V();
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/JythonInterpreterTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/JythonInterpreterTest.java
@@ -147,7 +147,7 @@ public class JythonInterpreterTest {
 	 * @throws Exception
 	 */
 	@Test
-	@Order(2)
+	@Order(3)
 	public void completionServerObjectTest2() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
@@ -168,51 +168,51 @@ public class JythonInterpreterTest {
 	 * @throws Exception
 	 */
 	@Test
-	@Order(2)
+	@Order(4)
 	public void completionQueryObjectTest() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
 				.iterator()
 				.next()
-				.complete("query.cal\t", 0, completions);
+				.complete("query.allCal\t", 0, completions);
 		outContent.flush();
 		errContent.flush();
 
-		assertTrue(completions.contains("calls()"));
+		assertTrue(completions.contains("allCalls()"));
 		assertEquals(1, completions.size());
 	}
 
 	/**
-	 * Test behavior of tab completion for "server.sho<TAB>"
+	 * Test behavior of tab completion for "query.allCalls().<TAB>"
 	 *
 	 * @throws Exception
 	 */
 	@Test
-	@Order(2)
+	@Order(5)
 	public void completionQueryObjectTest2() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
 				.iterator()
 				.next()
-				.complete("query.calls().\t", 0, completions);
+				.complete("q.allCalls().\t", 0, completions);
 		outContent.flush();
 		errContent.flush();
 
-		assertTrue(completions.contains("name()"));
+		assertTrue(completions.contains("next()"));
 	}
 
 	@Test
-	@Order(3)
+	@Order(6)
 	public void simpleJythonTest() throws Exception {
 		// Just for testing: We can run normal Gremlin queries:
-		Object result = interp.query("q.V().toSet()"); // Get all (!) nodes
+		Object result = interp.query("q.V([]).toSet()"); // Get all (!) nodes
 		assertEquals(HashSet.class, result.getClass());
 	}
 
 	@Test
-	@Order(4)
+	@Order(7)
 	public void crymlinOverJythonTest() throws Exception {
 		// Run crymlin queries as strings and get back the results as Java objects:
 		List<Vertex> classes = (List<Vertex>) interp.query("crymlin.recorddeclarations().toList()");


### PR DESCRIPTION
This PR brings many minor improvement to the Crymlin console:

- the dreaded `1st arg can't be coerced to String[]` for vararg methods is solved by switching from jython-gremlin to standard jython
- better tab completion behavior
- extension of the Crymlin query language: several more traversal sources and steps
- clearer `help()` output