### PR TITLE
Update to CPG v2.3.0

### DIFF
--- a/src/test/java/de/fraunhofer/aisec/crymlin/GraphTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/GraphTest.java
@@ -237,7 +237,7 @@ class GraphTest {
 			Optional<Long> count = crymlin.functions()
 					.count()
 					.tryNext();
-			assertEquals(16, count.get());
+			assertEquals(17, count.get());
 		}
 	}
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/OGMTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/OGMTest.java
@@ -231,7 +231,7 @@ public class OGMTest {
 					MethodDeclaration.class.getSimpleName(),
 					OverflowDatabase.getSubclasses(MethodDeclaration.class));
 		long mdCount = traversal.count().next();
-		assertEquals(16, mdCount, "Expected exactly 15 MethodDeclarations");
+		assertEquals(17, mdCount, "Expected exactly 17 MethodDeclarations");
 	}
 
 	@Test


### PR DESCRIPTION
Update to latest CPG release v2.3.0. This will also close #63.

This currently fixes:
*  Failing test due to increased method declaration count (de.fraunhofer.aisec.crymlin.GraphTest#crymlinFunctionsTest, de.fraunhofer.aisec.crymlin.OGMTest#countMethodDeclarations)