### PR TITLE
Add descriptions for findings

### DIFF
--- a/src/dist/mark/botan/rules_tr-2102-1.mark
+++ b/src/dist/mark/botan/rules_tr-2102-1.mark
@@ -30,7 +30,7 @@ rule _2_1_2_1_02_CCM_TagSize {
 	using Botan.Cipher_Mode as cm
 	when _starts_with(_split(cm.algorithm, "/", 1), "CCM")
 	ensure _between(_split(cm.algorithm, "/", 1), "(", ")") >= 8 // 8 byte = 64 bit
-	onfail  _2_1_2_2_03_GCM_TagSize
+	onfail  _2_1_2_2_02_CCM_TagSize
 }
 
 // NOTE: rule 2.1.2.2.01 seems to be not checkable. We cannot sufficiently reason about the dynamic behaviour of the program to check this rule.

--- a/src/dist/mark/bouncycastle/RulesTR_Cipher.mark
+++ b/src/dist/mark/bouncycastle/RulesTR_Cipher.mark
@@ -107,7 +107,7 @@ rule ID_2_1_2_2_02 {
         (_has_value(gcm.src) && _length(gcm.src) == 12) /* in bytes */
         || (_has_value(gcm.len) && gcm.len == 12)
     onfail
-        InvalidGCMAuthtenticationNonceLength
+        InvalidGCMAuthenticationNonceLength
 }
 
 /**

--- a/src/dist/mark/findingDescription.json
+++ b/src/dist/mark/findingDescription.json
@@ -1,4 +1,417 @@
 {
+  "InvalidProvider_AlgorithmParameterGenerator": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_AlgorithmParameters": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_CertificateFactory": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_CertPathBuilder": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_CertPathValidator": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_CertStore": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_Cipher": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_KeyAgreement": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_KeyFactory": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_KeyGenerator": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_KeyPairGenerator": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_KeyStore": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_Mac": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_MessageDigest": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_SecretKeyFactory": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_SecureRandom": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidProvider_Signature": {
+    "fullDescription": {
+      "text": "The selection of specific cryptographic implementations depends on the selected cryptographic service provider. Without specifying a specific cryptographic service provider, the system may select an undesirable one."
+    },
+    "shortDescription": {
+      "text": "Invalid cryptographic service provider"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use Bouncy Castle as cryptographic service provider"
+        }
+      }
+    ]
+  },
+  "InvalidOrderOfCipherOperations": {
+    "fullDescription": {
+      "text": "An incorrect order of operations on a Cipher object was detected. An incorrect order can lead to security weaknesses, for example, when initialization steps are omitted."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operations on Cipher"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order of: instantiate, initialize, possibly multiple update and a final finalize."
+        }
+      }
+    ]
+  },
+  "InvalidOrderforAEAD": {
+    "fullDescription": {
+      "text": "An incorrect order of operations on a Cipher object with AAD was detected. An incorrect order can lead to security weaknesses, for example, when initialization steps are omitted."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operations on Cipher with AAD"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order of: instantiate, initialize, possibly providing AAD, possibly multiple update and a final finalize."
+        }
+      }
+    ]
+  },
+  "Invalid_TR21021_Cipher": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A cipher was detected that does not match one of the recommended ciphers by BSI TR-02102. Use of weak or unspecified ciphers may not guarantee sufficient security."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified cipher"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use AES as symmetric-key (cf. 2.1) or RSA for asymmetric-key algorithm (cf. 3)"
+        }
+      }
+    ]
+  },
+  "InvalidCipherModeforAESBlockCipher": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A cipher mode for symmetric-key algorithms was detected that does not match one of the recommended cipher modes by BSI TR-02102. Use of weak or unspecified cipher modes may not guarantee sufficient security."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified cipher mode for symmetric-key algorithms"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following cipher modes: CCM, GCM, CBC, CTR (cf. 2.1.1)."
+        }
+      }
+    ]
+  },
+  "InsufficientCCMTagLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The authentication tag used with the cipher mode CCM in symmetric-key algorithms is too short. Short authentication tags increase the risk that data manipulations are not recognized."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of the CCM authentication tag"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use authentication tags with a length of at least 64 bits (cf. 2.1.2)."
+        }
+      }
+    ]
+  },
+  "InvalidGCMAuthenticationNonceLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The nonce for the cipher mode GCM in symmetric-key algorithms is incorrect. A specific length of 96 bits has been shown to be favourable."
+    },
+    "shortDescription": {
+      "text": "Incorrect length of GCM nonce"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use nonce with a length of 96 bits (cf. 2.1.2)."
+        }
+      }
+    ]
+  },
+  "InsufficientGCMTagLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The authentication tag used with the cipher mode GCM in symmetric-key algorithms is too short. Short authentication tags increase the risk that data manipulations are not recognized."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of the GCM authentication tag"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use authentication tags with a length of at least 96 bits (cf. 2.1.2)."
+        }
+      }
+    ]
+  },
+  "InvalidCBCIV": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The IV used with the cipher mode CBC is not sufficiently unpredictable. Predictable IVs, which an attacker could guess, compromises the security guarantees of CBC cipher mode."
+    },
+    "shortDescription": {
+      "text": "Insufficient quality of IV for CBC cipher mode"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use an unpredictable IV, for example, by using an initialized PRNG (cf. 2.1.2 and B.2)."
+        }
+      }
+    ]
+  },
+  "InvalidCBCPadding": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified padding method was used with CBC cipher mode. An unspecified padding method may leak information about encrypted blocks allowing an attacker to compromise security."
+    },
+    "shortDescription": {
+      "text": "Invalid padding used with CBC cipher mode"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following padding methods: ISO-Padding, PKCS#7-Padding, ESP-Padding (cf. 2.1.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientAESCTRIntegrityProtection": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "Symmetric-key algorithm in CTR cipher mode is used without ensuring the integrity. Without integrity alterations of ciphertext may cause targeted but undetected changes in the plaintext."
+    },
+    "shortDescription": {
+      "text": "Insufficient integrity protection of symmetric-key algorithm in CTR cipher mode"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use a separate cryptographic mechanism, such as MAC, to ensure integrity (cf. 2.2)"
+        }
+      }
+    ]
+  },
   "InvalidRSAPadding": {
     "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
     "fullDescription": {
@@ -10,19 +423,169 @@
     "fixes": [
       {
         "description": {
-          "text": "Use RSA with EME-OAEP padding."
+          "text": "Use RSA with EME-OAEP padding (cf. 3.6)."
         }
       }
     ]
   },
-  "InvalidGCMAuthtenticationNonceLength": {
+  "InsufficientRSAKeylength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An RSA key of insufficient length is used. Short keys permit feasible brute-force attacks."
+    },
     "shortDescription": {
-      "text": "GCM nonce length should be at least 12 bytes"
-    }
+      "text": "Insufficient length of RSA key"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 2000 bits until end of 2023 or at least 3000 bits past 2023 (cf. 3.6)."
+        }
+      }
+    ]
   },
-  "InsufficientGCMTagLength": {
+  "InvalidHashFunction": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified hash function is being used. Unspecified hash functions may be weak to attacks."
+    },
     "shortDescription": {
-      "text": "GCM tag length should be at least 12 bytes"
-    }
+      "text": "Use of an unspecified hash function"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use on of the following specified hash functions: SHA-256, SHA-512/256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512 (cf. 4)."
+        }
+      }
+    ]
+  },
+  "InvalidMACAlgorithm": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified message authentication code (MAC) is being used. Unspecified MACs may be weak to attacks."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified message authentication code (MAC)"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use on of the following specified MACs: CMAC, HMAC, GMAC (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientCMACKeyLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The used key for CMAC is not long enough. Short keys may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient key length used in CMAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use keys for CMAC with a length of at least 128 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientHMACKeyLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The used key for HMAC is not long enough. Short keys may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient key length used in HMAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use keys for HMAC with a length of at least 128 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientGMACKeyLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The used key for GMAC is not long enough. Short keys may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient key length used in GMAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use keys for GMAC with a length of at least 128 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientCMACTagLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The generated tag by CMAC is not long enough. Short tags may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient tag length generated through CMAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use tags for CMAC with a length of at least 96 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientHMACTagLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The generated tag by HMAC is not long enough. Short tags may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient tag length generated through HMAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use tags for HMAC with a length of at least 96 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InsufficientGMACTagLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The generated tag by HMAC is not long enough. Short tags may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient tag length generated through HMAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use tags for HMAC with a length of at least 96 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "InvalidSignatureAlgorithm": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified signature algorithm is being used. Unspecified signature algorithm may not provide sufficiently strong security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified signature algorithm."
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following specified signature algorithms: RSA with EMSA-PSS or DSS 2 and 3 (cf. 5.4.1), DSA (cf. 5.4.2), ECDSA, ECKDSA or ECGDSA (cf. 5.4.3), Merkle signatures (cf. 5.4.4).l"
+        }
+      }
+    ]
   }
 }

--- a/src/dist/mark/findingDescription.json
+++ b/src/dist/mark/findingDescription.json
@@ -583,7 +583,480 @@
     "fixes": [
       {
         "description": {
-          "text": "Use one of the following specified signature algorithms: RSA with EMSA-PSS or DSS 2 and 3 (cf. 5.4.1), DSA (cf. 5.4.2), ECDSA, ECKDSA or ECGDSA (cf. 5.4.3), Merkle signatures (cf. 5.4.4).l"
+          "text": "Use one of the following specified signature algorithms: RSA with EMSA-PSS or DSS 2 and 3 (cf. 5.4.1), DSA (cf. 5.4.2), ECDSA, ECKDSA or ECGDSA (cf. 5.4.3), Merkle signatures (cf. 5.4.4)."
+        }
+      }
+    ]
+  },
+  "MACOrder": {
+    "fullDescription": {
+      "text": "An incorrect order of operations on a MessageAuthenticationCode object was detected. An incorrect order can lead to security weaknesses, for example, when initialization steps are omitted."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operations on MessageAuthenticationCode"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order of: create, initialize, start, possibly multiple update followed by finalize or verify, or a process."
+        }
+      }
+    ]
+  },
+  "PipeOrder_Fail": {
+    "fullDescription": {
+      "text": "An incorrect order of operations on a Pipe object was detected. An incorrect order can lead to security weaknesses, for example, when initialization steps are omitted."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operations on Pipe"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order of: create, possibly multiple edit, possibly multiple process_msg, or start followed by possibly multiple put_data and an end, possibly multiple read and an optional final reset."
+        }
+      }
+    ]
+  },
+  "WrongUseOfBotan_CipherMode": {
+    "fullDescription": {
+      "text": "The Pipe was not initialized with a Cipher_Mode object."
+    },
+    "shortDescription": {
+      "text": "Pipe not initialized with cipher"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Add a Cipher_Mode object as a filter."
+        }
+      }
+    ]
+  },
+  "PrivKeyOrder": {
+    "fullDescription": {
+      "text": "The order of operations on a Private_Key object is invalid. May use unchecked keys causing vulnerabilities."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operation on Private_Key objects"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order: create; or load and check_key"
+        }
+      }
+    ]
+  },
+  "PubKeyOrder": {
+    "fullDescription": {
+      "text": "The order of operations on a Public_Key object is invalid. May use unchecked keys causing vulnerabilities."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operation on Public_Key objects"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order: create; or load and check_key"
+        }
+      }
+    ]
+  },
+  "RNGOrder": {
+    "fullDescription": {
+      "text": "The order of operations on a *RNG object is invalid."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operation on *RNG objects"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order: create and possibly multiple get_random."
+        }
+      }
+    ]
+  },
+  "SignatureOrder": {
+    "fullDescription": {
+      "text": "The order of operations on a PK_Verifier object is invalid."
+    },
+    "shortDescription": {
+      "text": "Invalid order of operation on PK_Verifier objects"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Ensure the correct order: create; possible multiple of possibly multiple update followed by check_after_update; OR check_whole_msg."
+        }
+      }
+    ]
+  },
+  "_2_01_BlockCiphers": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A symmetric-key cipher was detected that does not match one of the recommended ciphers by BSI TR-02102. Use of weak or unspecified ciphers may not guarantee sufficient security."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified cipher"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use AES as symmetric-key (cf. 2.1)"
+        }
+      }
+    ]
+  },
+  "_2_01_KeyLength": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A symmetric-key cipher was detected that does not have the recommended key length by BSI TR-02102. Use of short keys may not guarantee sufficient security."
+    },
+    "shortDescription": {
+      "text": "Insufficient key length"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use key lengths of: 128, 192 or 256 bits (cf. 2.1)."
+        }
+      }
+    ]
+  },
+  "WrongMode": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A cipher mode for symmetric-key algorithms was detected that does not match one of the recommended cipher modes by BSI TR-02102. Use of weak or unspecified cipher modes may not guarantee sufficient security."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified cipher mode for symmetric-key algorithms"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following cipher modes: CCM, GCM, CBC, CTR (cf. 2.1.1)."
+        }
+      }
+    ]
+  },
+  "_2_1_2_2_02_CCM_TagSize": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The authentication tag used with the cipher mode CCM in symmetric-key algorithms is too short. Short authentication tags increase the risk that data manipulations are not recognized."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of the CCM authentication tag"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use authentication tags with a length of at least 64 bits (cf. 2.1.2)."
+        }
+      }
+    ]
+  },
+  "_2_1_2_2_03_GCM_TagSize": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The authentication tag used with the cipher mode GCM in symmetric-key algorithms is too short. Short authentication tags increase the risk that data manipulations are not recognized."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of the GCM authentication tag"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use authentication tags with a length of at least 96 bits (cf. 2.1.2)."
+        }
+      }
+    ]
+  },
+  "NoRandomIV": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The IV used with the cipher mode CBC is not sufficiently unpredictable. Predictable IVs, which an attacker could guess, compromises the security guarantees of CBC cipher mode."
+    },
+    "shortDescription": {
+      "text": "Insufficient quality of IV for CBC cipher mode"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use an unpredictable IV, for example, by using an initialized PRNG (cf. 2.1.2 and B.2)."
+        }
+      }
+    ]
+  },
+  "TR02102_3_3_02_CurveParams": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The use of unspecified EC parameters was detected. Unspecified EC parameters may not provide sufficient security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of unspecified EC parameters"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following EC parameters: brainpool256r1, brainpool320r1, brainpool384r1, brainpool512r1 (cf. B.3)."
+        }
+      }
+    ]
+  },
+  "_3_3_03_ECIES_KDF": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The use of unspecified KDF with ECIES was detected. Unspecified KDF may not provide sufficient security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of unspecified KDF with ECIES"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following EC parameters: SP800-56C or HKDF with HMAC(SHA-256), HMAC(SHA-512-256), HMAC(SHA-384), HMAC(SHA-512), HMAC(SHA3-256), HMAC(SHA3-384), HMAC(SHA3-512) (cf. 3.4)."
+        }
+      }
+    ]
+  },
+  "_3_4_01_DLIES_KDF": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The use of unspecified KDF with DLIES was detected. Unspecified KDF may not provide sufficient security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of unspecified KDF with DLIES"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following EC parameters: HKDF with HMAC(SHA-256), HMAC(SHA-512-256), HMAC(SHA-384), HMAC(SHA-512), HMAC(SHA3-256), HMAC(SHA3-384), HMAC(SHA3-512) (cf. 3.5)."
+        }
+      }
+    ]
+  },
+  "_3_4_02_DLIES_KEYLEN": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The length of the key used with DLIES is too short. Short keys do not provide sufficient security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of insufficient key length with DLIES"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use keys with a length of at least 3000 bits (cf. 3.5)."
+        }
+      }
+    ]
+  },
+  "_3_4_02_DLIES_KEYLEN_2022": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The length of the key used with DLIES is too short. Short keys do not provide sufficient security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of insufficient key length with DLIES until 2022"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Until 2022 use keys with a length of at least 200 bits (cf. 3.5)."
+        }
+      }
+    ]
+  },
+  "_01_HashFunctions": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified hash function is being used. Unspecified hash functions may be weak to attacks."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified hash function"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use on of the following specified hash functions: SHA-256, SHA-512/256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512 (cf. 4)."
+        }
+      }
+    ]
+  },
+  "_5_3_01_MAC": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified message authentication code (MAC) is being used. Unspecified MACs may be weak to attacks."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified message authentication code (MAC)"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use on of the following specified MACs: CMAC/OMAC, HMAC, GMAC (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "_5_3_02_MAC_KEYLEN": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The used key with MAC is not long enough. Short keys may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient key length used with MAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use keys with a length of at least 128 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "_5_3_03_MAC_NONCELEN": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "The used nonce with MAC is not long enough. Short nonce may make brute-force attacks more feasible."
+    },
+    "shortDescription": {
+      "text": "Insufficient nonce length used with MAC"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use nonce with a length of at least 96 bits (cf. 5.3)."
+        }
+      }
+    ]
+  },
+  "_5_4_1_01_RSA_SIG_Format": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified RSA signature algorithm is being used. Unspecified signature algorithm may not provide sufficiently strong security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified RSA signature algorithm."
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following specified signature algorithms: EMSA4, ISO_9796_DS2, ISO_9796_DS3 (cf. 5.4.1)."
+        }
+      }
+    ]
+  },
+  "_5_4_1_02_RSA_SIG_KeyLen": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A key of insufficient length is used with RSA signature algorithms. Short keys permit feasible brute-force attacks."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of key with RSA signature algorithm"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 3000 bits past 2023 (cf. 5.4.1)."
+        }
+      }
+    ]
+  },
+  "_5_4_1_02_RSA_SIG_KeyLen_2022": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An RSA key of insufficient length is used with RSA signature algorithms. Short keys permit feasible brute-force attacks."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of key with RSA signature algorithm"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 2000 bits until 2023 (cf. 5.4.1)."
+        }
+      }
+    ]
+  },
+  "_5_4_2_01_DSA_SIG_KeyLen": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A key of insufficient length is used with DSA signature algorithms. Short keys permit feasible brute-force attacks."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of key with DSA signature algorithm"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 3000 bits past 2022 (cf. 5.4.1)."
+        }
+      }
+    ]
+  },
+  "_5_4_2_01_DSA_SIG_KeyLen_2022": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A key of insufficient length is used with DSA signature algorithms. Short keys permit feasible brute-force attacks."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of key with DSA signature algorithm"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 2000 bits until 2022 (cf. 5.4.1)."
+        }
+      }
+    ]
+  },
+  "_5_4_3_01_ECDSA_SIG": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "An unspecified EC signature algorithm is being used. Unspecified signature algorithm may not provide sufficiently strong security guarantees."
+    },
+    "shortDescription": {
+      "text": "Use of an unspecified EC signature algorithm."
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use one of the following specified EC signature algorithms: ECDSA, ECKDSA or ECGDSA (cf. 5.4.3)."
+        }
+      }
+    ]
+  },
+  "_7_2_2_1_01_DH_KEYLEN": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A key of insufficient length is used with DSA signature algorithms. Short keys permit feasible brute-force attacks."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of key with DH key exchange algorithm"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 3000 bits past 2022 (cf. 7.2.1)."
+        }
+      }
+    ]
+  },
+  "_7_2_2_1_01_DH_KEYLEN_2022": {
+    "helpUri": "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR02102/BSI-TR-02102.pdf",
+    "fullDescription": {
+      "text": "A key of insufficient length is used with DSA signature algorithms. Short keys permit feasible brute-force attacks."
+    },
+    "shortDescription": {
+      "text": "Insufficient length of key with DH key exchange algorithm"
+    },
+    "fixes": [
+      {
+        "description": {
+          "text": "Use at least keys with a length of 2000 bits until 2022 (cf. 7.2.1)."
         }
       }
     ]


### PR DESCRIPTION
This PR adds user friendly descriptions for MARK rules.

Evaluating MARK rules generate findings. These findings use the rule name and if the rule evaluation fails the `onfail` identifier. This is not very user friendly, because it does not help the user to understand the problem nor suggest any fix. This `findingDescription.json` adds more detailed findings descriptions for MARK rules distributed with Codyze.

This PR closes #14 