### PR TITLE
Prevent connection to already connected database

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/analysis/server/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/analysis/server/AnalysisServer.java
@@ -439,7 +439,9 @@ public class AnalysisServer {
 		db.clearDatabase();
 
 		// connect
-		db.connect();
+		if (!db.isConnected()) {
+			db.connect();
+		}
 
 		// Persist the result
 		db.saveAll(result.getTranslationUnits());


### PR DESCRIPTION
When connecting to an already connected database, an file lock exception was triggered. The clearDatabase operation already opens a new connection to the database. Therefore, a connection via connect is only necessary if the connection wasn't established for some reason.

Fixes #75