### PR TITLE
Update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,24 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":assignAndReview(fwendland)",
+    ":enableVulnerabilityAlerts",
+    ":separateMultipleMajorReleases"
   ],
-   "ignoreDeps": [
-                  "de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark",
-                  "org.apache.tinkerpop:gremlin-core",
-                  "org.apache.tinkerpop:gremlin-driver",
-                  "org.apache.tinkerpop:gremlin-python",
-                  "org.apache.tinkerpop:neo4j-gremlin",
-                  "org.apache.tinkerpop:tinkergraph-gremlin",
-                  "com.steelbridgelabs.oss:neo4j-gremlin-bolt"
-                 ],
-   "ignorePaths": ["scripts", "docs"]
+  "ignoreDeps": [
+    "de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark",
+    "org.apache.tinkerpop:gremlin-core",
+    "org.apache.tinkerpop:gremlin-driver",
+    "org.apache.tinkerpop:gremlin-python",
+    "org.apache.tinkerpop:neo4j-gremlin",
+    "org.apache.tinkerpop:tinkergraph-gremlin",
+    "com.steelbridgelabs.oss:neo4j-gremlin-bolt"
+  ],
+  "ignorePaths": ["scripts", "docs"],
+  "packageRules": [
+    {
+      "groupName": "picocli packages",
+      "packagePatterns": ["^info.picocli:"]
+    }
+  ]
 }


### PR DESCRIPTION
*  Automatically assigns PR to maintainer and add as reviewer
*  Explicitly enables vulnerability alerts
*  Creates separate PR for different major version
*  Adds package rule to update picocli dependencies in unison