### PR TITLE
Remove code smells from unit tests

### DIFF
--- a/src/test/java/de/fraunhofer/aisec/crymlin/AbstractMarkTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/AbstractMarkTest.java
@@ -156,7 +156,7 @@ public abstract class AbstractMarkTest {
 			}
 		}
 
-		assertEquals(0, findings.size(), findings.stream().map(f -> f.toString()).collect(Collectors.joining()));
+		assertEquals(0, findings.size(), findings.stream().map(Finding::toString).collect(Collectors.joining()));
 	}
 
 }

--- a/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerBotanTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerBotanTest.java
@@ -6,7 +6,6 @@ import de.fraunhofer.aisec.analysis.structures.AnalysisContext;
 import de.fraunhofer.aisec.analysis.structures.ServerConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
-import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
 import de.fraunhofer.aisec.markmodel.MEntity;
 import de.fraunhofer.aisec.markmodel.MRule;
 import de.fraunhofer.aisec.markmodel.Mark;
@@ -24,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class AnalysisServerBotanTest {
 
@@ -67,16 +65,16 @@ public class AnalysisServerBotanTest {
 	}
 
 	@AfterAll
-	public static void teardown() throws Exception {
+	public static void teardown() {
 		// Stop the analysis server
 		server.stop();
 	}
 
 	/** Test analysis context - additional in-memory structures used for analysis. */
 	@Test
-	public void contextTest() {
+	void contextTest() {
 		// Get analysis context from scratch
-		AnalysisContext ctx = (AnalysisContext) AnalysisServerBotanTest.result;
+		AnalysisContext ctx = AnalysisServerBotanTest.result;
 
 		// We expect no methods (as there is no class)
 		assertNotNull(ctx);
@@ -84,7 +82,7 @@ public class AnalysisServerBotanTest {
 	}
 
 	@Test
-	public void markModelTest() throws Exception {
+	void markModelTest() {
 		Mark markModel = server.getMarkModel();
 		assertNotNull(markModel);
 		List<MRule> rules = markModel.getRules();
@@ -95,8 +93,8 @@ public class AnalysisServerBotanTest {
 	}
 
 	@Test
-	public void markEvaluationTest() throws Exception {
-		AnalysisContext ctx = (AnalysisContext) AnalysisServerBotanTest.result;
+	void markEvaluationTest() {
+		AnalysisContext ctx = AnalysisServerBotanTest.result;
 		assertNotNull(ctx);
 		List<String> findings = new ArrayList<>();
 		assertNotNull(ctx.getFindings());

--- a/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerBotanTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerBotanTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AnalysisServerBotanTest {
+class AnalysisServerBotanTest {
 
 	private static AnalysisServer server;
 	private static AnalysisContext result;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerQueriesTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerQueriesTest.java
@@ -61,7 +61,7 @@ public class AnalysisServerQueriesTest {
 	}
 
 	@AfterAll
-	public static void teardown() throws Exception {
+	public static void teardown() {
 		// Stop the analysis server
 		server.stop();
 	}
@@ -70,7 +70,7 @@ public class AnalysisServerQueriesTest {
 	 * Test analysis context - additional in-memory structures used for analysis.
 	 */
 	@Test
-	public void contextTest() {
+	void contextTest() {
 		// Get analysis context from scratch
 		AnalysisContext ctx = AnalysisServerQueriesTest.result;
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerQueriesTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/AnalysisServerQueriesTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class AnalysisServerQueriesTest {
+class AnalysisServerQueriesTest {
 
 	private static AnalysisServer server;
 	private static AnalysisContext result;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BotanRuleTR_Test.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BotanRuleTR_Test.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-public class BotanRuleTR_Test extends AbstractMarkTest {
+class BotanRuleTR_Test extends AbstractMarkTest {
 
 	@Test
 	void test_rule_2_01() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BotanRuleTR_Test.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BotanRuleTR_Test.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public class BotanRuleTR_Test extends AbstractMarkTest {
 
 	@Test
-	public void test_rule_2_01() throws Exception {
+	void test_rule_2_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/2_01.cpp", "mark/botan/");
 
 		expected(findings,
@@ -25,7 +25,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_2_1_01() throws Exception {
+	void test_rule_2_1_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/2_1_01.cpp", "mark/botan/");
 
 		expected(findings,
@@ -40,7 +40,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_2_1_2_1_02() throws Exception {
+	void test_rule_2_1_2_1_02() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/2_1_2_1_02.cpp", "mark/botan/");
 
 		expected(findings,
@@ -56,7 +56,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_2_1_2_2_03() throws Exception {
+	void test_rule_2_1_2_2_03() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/2_1_2_2_03.cpp", "mark/botan/");
 
 		expected(findings,
@@ -71,7 +71,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_2_1_2_3_01() throws Exception {
+	void test_rule_2_1_2_3_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/2_1_2_3_01.cpp", "mark/botan/");
 
 		/* missing
@@ -91,7 +91,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_3_3_02() throws Exception {
+	void test_rule_3_3_02() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/3_3_02.cpp", "mark/botan/");
 		expected(findings,
 			"line 21: Rule _3_3_03_ECIES_KDF verified", // ok
@@ -100,7 +100,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_3_3_03() throws Exception {
+	void test_rule_3_3_03() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/3_3_03.cpp", "mark/botan/");
 		expected(findings,
 			"line 22: Rule _3_3_03_ECIES_KDF verified", // ok
@@ -109,7 +109,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_3_4_01() throws Exception {
+	void test_rule_3_4_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/3_4_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 30: Violation against Order: Base mac is not correctly terminated. Expected one of [m.init] to follow the correct last call on this base. (MACOrder)", // ok
@@ -125,7 +125,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_3_4_02() throws Exception {
+	void test_rule_3_4_02() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/3_4_02.cpp", "mark/botan/");
 		expected(findings,
 			"line 17: Rule _3_4_02_DLIES_KEYLEN_2022 verified", // ok
@@ -140,7 +140,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_4_01() throws Exception {
+	void test_rule_4_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/4_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 8: Verified Order: HashOrder", // ok
@@ -153,7 +153,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_3_01() throws Exception {
+	void test_rule_5_3_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_3_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 12: Violation against Order: Base mac is not correctly terminated. Expected one of [m.init] to follow the correct last call on this base. (MACOrder)", // ok
@@ -163,7 +163,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_3_02() throws Exception {
+	void test_rule_5_3_02() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_3_02.cpp", "mark/botan/");
 		expected(findings, "line 11: Rule _5_3_02_MAC_KEYLEN verified", // ok
 			"line 14: Rule _5_3_01_MAC verified", // ok
@@ -173,7 +173,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_3_03() throws Exception {
+	void test_rule_5_3_03() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_3_03.cpp", "mark/botan/");
 		expected(findings,
 			"line 12: Rule _5_3_02_MAC_KEYLEN verified", // ok
@@ -184,7 +184,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_4_1_01() throws Exception {
+	void test_rule_5_4_1_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_4_1_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 10: Verified Order: PrivKeyOrder",
@@ -196,7 +196,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_4_1_02() throws Exception {
+	void test_rule_5_4_1_02() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_4_1_02.cpp", "mark/botan/");
 		expected(findings,
 			"line 11: Rule _5_4_1_02_RSA_SIG_KeyLen_2022 verified", // ok
@@ -208,7 +208,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_4_2_01() throws Exception {
+	void test_rule_5_4_2_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_4_2_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 14: Verified Order: SignatureOrder", // ok
@@ -219,7 +219,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_5_4_3_01() throws Exception {
+	void test_rule_5_4_3_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/5_4_3_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 14: Verified Order: SignatureOrder", // ok
@@ -229,7 +229,7 @@ public class BotanRuleTR_Test extends AbstractMarkTest {
 	}
 
 	@Test
-	public void test_rule_7_2_2_1_01() throws Exception {
+	void test_rule_7_2_2_1_01() throws Exception {
 		Set<Finding> findings = performTest("botan_rule_tr_test/7_2_2_1_01.cpp", "mark/botan/");
 		expected(findings,
 			"line 13: Rule _7_2_2_1_01_DH_KEYLEN verified", // ok

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class BuiltInTest extends AbstractMarkTest {
+class BuiltInTest extends AbstractMarkTest {
 
 	@Test
 	void split_1() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
@@ -7,20 +7,17 @@ import de.fraunhofer.aisec.analysis.structures.Finding;
 import de.fraunhofer.aisec.analysis.structures.ListValue;
 import de.fraunhofer.aisec.crymlin.builtin.BuiltinHelper;
 import de.fraunhofer.aisec.crymlin.builtin.InvalidArgumentException;
-import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class BuiltInTest extends AbstractMarkTest {
 
 	@Test
-	public void split_1() throws Exception {
+	void split_1() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/simplesplit_splitstring.cpp", "mark_cpp/splitstring.mark");
 
 		expected(findings,
@@ -31,7 +28,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void is_instance_1() throws Exception {
+	void is_instance_1() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/simple_instancestring.cpp", "mark_cpp/instancestring.mark");
 
 		expected(findings,
@@ -39,7 +36,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void eog_connection_1() throws Exception {
+	void eog_connection_1() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/simple_eog_connection.cpp", "mark_cpp/eog_connection.mark");
 
 		expected(findings,
@@ -49,7 +46,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void direct_eog_connection_1() throws Exception {
+	void direct_eog_connection_1() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/simple_eog_connection.cpp", "mark_cpp/direct_eog_connection.mark");
 
 		expected(findings,
@@ -59,7 +56,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void dimensionLengthJava() throws Exception {
+	void dimensionLengthJava() throws Exception {
 		Set<Finding> findings = performTest("mark_java/length.java", "mark_java/length.mark");
 
 		expected(findings,
@@ -68,7 +65,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void isJava() throws Exception {
+	void isJava() throws Exception {
 		Set<Finding> findings = performTest("mark_java/is.java", "mark_java/is.mark");
 
 		expected(findings,
@@ -77,7 +74,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void hasValueJava() throws Exception {
+	void hasValueJava() throws Exception {
 		Set<Finding> findings = performTest("mark_java/has_value.java", "mark_java/has_value.mark");
 
 		expected(findings,
@@ -86,7 +83,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void extractResponsibleVertices() {
+	void extractResponsibleVertices() {
 
 		ListValue lv = new ListValue();
 		ConstantValue cv1 = ConstantValue.of(2);
@@ -161,7 +158,7 @@ public class BuiltInTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void verifyArgumentTypesOrThrow() throws InvalidArgumentException {
+	void verifyArgumentTypesOrThrow() throws InvalidArgumentException {
 		ListValue lv = new ListValue();
 		lv.add(ConstantValue.of(2));
 		lv.add(ConstantValue.of(3));

--- a/src/test/java/de/fraunhofer/aisec/crymlin/CommandsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/CommandsTest.java
@@ -2,25 +2,13 @@
 package de.fraunhofer.aisec.crymlin;
 
 import de.fraunhofer.aisec.analysis.Commands;
-import de.fraunhofer.aisec.analysis.CrymlinConsole;
 import de.fraunhofer.aisec.analysis.JythonInterpreter;
 import de.fraunhofer.aisec.analysis.server.AnalysisServer;
 import de.fraunhofer.aisec.analysis.structures.ServerConfiguration;
 import de.fraunhofer.aisec.analysis.structures.TypestateMode;
-import de.fraunhofer.aisec.cpg.helpers.Benchmark;
-import de.fraunhofer.aisec.crymlin.connectors.db.TraversalConnection;
-import de.fraunhofer.aisec.crymlin.dsl.CrymlinTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.step.util.BulkSet;
-import org.apache.tinkerpop.gremlin.structure.T;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.jupiter.api.Test;
 
-import javax.script.ScriptException;
 import java.io.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/ConstantValueTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/ConstantValueTest.java
@@ -11,28 +11,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ConstantValueTest {
 
 	@Test
-	public void testTryOfInteger() {
+	void testTryOfInteger() {
 		int test = 42;
 		Optional<ConstantValue> res = ConstantValue.tryOf(test);
 		assertEquals(res.get().getValue(), test);
 	}
 
 	@Test
-	public void testTryOfFloat() {
+	void testTryOfFloat() {
 		float test = 42f;
 		Optional<ConstantValue> res = ConstantValue.tryOf(test);
 		assertEquals(res.get().getValue(), test);
 	}
 
 	@Test
-	public void testTryOfBoolean() {
+	void testTryOfBoolean() {
 		Boolean test = true;
 		Optional<ConstantValue> res = ConstantValue.tryOf(test);
 		assertEquals(res.get().getValue(), test);
 	}
 
 	@Test
-	public void testTryOfString() {
+	void testTryOfString() {
 		String test = "test";
 		Optional<ConstantValue> res = ConstantValue.tryOf(test);
 		assertEquals(res.get().getValue(), test);

--- a/src/test/java/de/fraunhofer/aisec/crymlin/ConstantValueTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/ConstantValueTest.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ConstantValueTest {
+class ConstantValueTest {
 
 	@Test
 	void testTryOfInteger() {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/ExpressionHelperTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/ExpressionHelperTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ExpressionHelperTest {
+class ExpressionHelperTest {
 
 	@Test
 	void testComparableInt() {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/ExpressionHelperTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/ExpressionHelperTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ExpressionHelperTest {
 
 	@Test
-	public void testComparableInt() {
+	void testComparableInt() {
 		assertEquals("0.0", ExpressionHelper.toComparableString(0));
 		assertEquals("0.0", ExpressionHelper.toComparableString(0.0));
 		assertEquals("1.0", ExpressionHelper.toComparableString(1));
@@ -19,7 +19,7 @@ public class ExpressionHelperTest {
 	}
 
 	@Test
-	public void testComparableDouble() {
+	void testComparableDouble() {
 		assertEquals("0.0", ExpressionHelper.toComparableString(0d));
 		assertEquals("0.0", ExpressionHelper.toComparableString(0.0d));
 		assertEquals("1.0", ExpressionHelper.toComparableString(1d));
@@ -29,7 +29,7 @@ public class ExpressionHelperTest {
 	}
 
 	@Test
-	public void testComparableString() {
+	void testComparableString() {
 		assertEquals("", ExpressionHelper.toComparableString(""));
 		assertEquals("a", ExpressionHelper.toComparableString("a"));
 		assertEquals("1.0", ExpressionHelper.toComparableString("1"));

--- a/src/test/java/de/fraunhofer/aisec/crymlin/FSMTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/FSMTest.java
@@ -25,7 +25,7 @@ class FSMTest {
 	private static Mark mark;
 
 	@BeforeAll
-	static void startup() throws Exception {
+	static void startup() {
 
 		URL resource = MarkLoadOutputTest.class.getClassLoader().getResource("mark/PoC_MS1/Botan_CipherMode.mark");
 		assertNotNull(resource);

--- a/src/test/java/de/fraunhofer/aisec/crymlin/FindingDescriptionTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/FindingDescriptionTest.java
@@ -4,7 +4,6 @@ package de.fraunhofer.aisec.crymlin;
 import de.fraunhofer.aisec.analysis.structures.Finding;
 import de.fraunhofer.aisec.analysis.structures.FindingDescription;
 import de.fraunhofer.aisec.cpg.sarif.Region;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/ForbiddenTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/ForbiddenTest.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ForbiddenTest extends AbstractMarkTest {
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/GithubTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/GithubTest.java
@@ -7,7 +7,6 @@ import de.fraunhofer.aisec.analysis.structures.ServerConfiguration;
 import de.fraunhofer.aisec.analysis.utils.TestAppender;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
-import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/GraphTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/GraphTest.java
@@ -6,7 +6,6 @@ import de.fraunhofer.aisec.analysis.structures.AnalysisContext;
 import de.fraunhofer.aisec.analysis.structures.ServerConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationConfiguration;
 import de.fraunhofer.aisec.cpg.TranslationManager;
-import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.graph.declarations.FunctionDeclaration;
 import de.fraunhofer.aisec.cpg.graph.declarations.MethodDeclaration;
 import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
@@ -255,8 +254,6 @@ class GraphTest {
 	 *
 	 * <p>
 	 * Note that we need to use labels which actually exist in our CPG and we must provide them in Tinkerpop's multi-label syntax (<label 1>::<label 2>).
-	 *
-	 * @throws Exception
 	 */
 	@SuppressWarnings("unchecked")
 	@Test

--- a/src/test/java/de/fraunhofer/aisec/crymlin/JCATest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/JCATest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public class JCATest extends AbstractMarkTest {
 
 	@Test
-	public void testBCProviderCipher() throws Exception {
+	void testBCProviderCipher() throws Exception {
 		Set<Finding> findings = performTest("java/jca/BCProviderCipher.java",
 			new String[] {
 					"java/jca/include/BouncyCastleProvider.java"
@@ -45,7 +45,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testBlockCipher() throws Exception {
+	void testBlockCipher() throws Exception {
 		Set<Finding> findings = performTest("java/jca/BlockCipher.java", "mark/bouncycastle/");
 
 		// possible lines: 10,14,28,22,26
@@ -70,7 +70,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testAESCCM() throws Exception {
+	void testAESCCM() throws Exception {
 		Set<Finding> findings = performTest("java/jca/AESCCM.java", "mark/bouncycastle/");
 
 		// possible lines: 18,22,23,24,28,30,31,36
@@ -92,7 +92,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testAESGCM() throws Exception {
+	void testAESGCM() throws Exception {
 		Set<Finding> findings = performTest("java/jca/AESGCM.java",
 			new String[] {
 					"java/jca/include/GCMParameterSpec.java"
@@ -129,7 +129,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testAESCBC() throws Exception {
+	void testAESCBC() throws Exception {
 		Set<Finding> findings = performTest("java/jca/AESCBC.java", "mark/bouncycastle/");
 
 		expected(findings,
@@ -172,7 +172,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testAESCTR() throws Exception {
+	void testAESCTR() throws Exception {
 		Set<Finding> findings = performTest("java/jca/AESCTR.java",
 			new String[] {
 					"java/jca/include/IvParameterSpec.java",
@@ -210,7 +210,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testBCMac() throws Exception {
+	void testBCMac() throws Exception {
 		Set<Finding> findings = performTest("java/jca/BCMac.java", "mark/bouncycastle/");
 
 		expected(findings,
@@ -248,7 +248,7 @@ public class JCATest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void testRSACipherTest() throws Exception {
+	void testRSACipherTest() throws Exception {
 		Set<Finding> findings = performTest("java/jca/BCRSACipher.java", "mark/bouncycastle/");
 
 		expected(findings,

--- a/src/test/java/de/fraunhofer/aisec/crymlin/JCATest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/JCATest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-public class JCATest extends AbstractMarkTest {
+class JCATest extends AbstractMarkTest {
 
 	@Test
 	void testBCProviderCipher() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/JythonInterpreterTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/JythonInterpreterTest.java
@@ -122,7 +122,7 @@ class JythonInterpreterTest {
 	 */
 	@Test
 	@Order(1)
-	public void completionSimpleTest() throws Exception {
+	void completionSimpleTest() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
@@ -147,7 +147,7 @@ class JythonInterpreterTest {
 	 */
 	@Test
 	@Order(2)
-	public void completionServerObjectTest() throws Exception {
+	void completionServerObjectTest() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
@@ -171,7 +171,7 @@ class JythonInterpreterTest {
 	 */
 	@Test
 	@Order(3)
-	public void completionServerObjectTest2() throws Exception {
+	void completionServerObjectTest2() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
@@ -192,7 +192,7 @@ class JythonInterpreterTest {
 	 */
 	@Test
 	@Order(4)
-	public void completionQueryObjectTest() throws Exception {
+	void completionQueryObjectTest() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
@@ -213,7 +213,7 @@ class JythonInterpreterTest {
 	 */
 	@Test
 	@Order(5)
-	public void completionQueryObjectTest2() throws Exception {
+	void completionQueryObjectTest2() throws Exception {
 		List<CharSequence> completions = new ArrayList<>();
 		jlineConsole.getReader()
 				.getCompleters()
@@ -228,7 +228,7 @@ class JythonInterpreterTest {
 
 	@Test
 	@Order(6)
-	public void simpleJythonTest() throws Exception {
+	void simpleJythonTest() throws Exception {
 		// Just for testing: We can run normal Gremlin queries:
 		Object result = interp.query("q.V([]).toSet()"); // Get all (!) nodes
 		assertEquals(HashSet.class, result.getClass());
@@ -236,7 +236,7 @@ class JythonInterpreterTest {
 
 	@Test
 	@Order(7)
-	public void crymlinOverJythonTest() throws Exception {
+	void crymlinOverJythonTest() throws Exception {
 		// Run crymlin queries as strings and get back the results as Java objects:
 		List<Vertex> classes = (List<Vertex>) interp.query("crymlin.records().toList()");
 		assertNotNull(classes);

--- a/src/test/java/de/fraunhofer/aisec/crymlin/LSPTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/LSPTest.java
@@ -22,7 +22,7 @@ class LSPTest {
 	private static AnalysisServer server;
 
 	@BeforeAll
-	static void setup() throws Exception {
+	static void setup() {
 		ClassLoader classLoader = AnalysisServerBotanTest.class.getClassLoader();
 
 		URL resource = classLoader.getResource("unittests/order.mark");

--- a/src/test/java/de/fraunhofer/aisec/crymlin/MarkCppTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/MarkCppTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class MarkCppTest extends AbstractMarkTest {
+class MarkCppTest extends AbstractMarkTest {
 
 	@Test
 	void nested_markvars() throws Exception {
@@ -45,7 +45,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	@Disabled // requires interprocedural context-insensitive dataflow analysis for constant resolution.
+	@Disabled("requires interprocedural context-insensitive dataflow analysis for constant resolution.")
 	void _01_assign() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/01_assign.cpp", "mark_cpp/01_assign.mark");
 		System.out.println("All findings:");
@@ -65,7 +65,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	@Disabled // requires interprocedural context-insensitive dataflow analysis of function argument for constant resolution.
+	@Disabled("requires interprocedural context-insensitive dataflow analysis of function argument for constant resolution.")
 	void _03_arg_as_param() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/03_arg_as_param.cpp", "mark_cpp/03_arg_as_param.mark");
 		System.out.println("All findings:");

--- a/src/test/java/de/fraunhofer/aisec/crymlin/MarkCppTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/MarkCppTest.java
@@ -2,39 +2,36 @@
 package de.fraunhofer.aisec.crymlin;
 
 import de.fraunhofer.aisec.analysis.structures.Finding;
-import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class MarkCppTest extends AbstractMarkTest {
 
 	@Test
-	public void nested_markvars() throws Exception {
+	void nested_markvars() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/nested_markvars.cpp", "mark_cpp/nested_markvars.mark");
 		expected(findings, "line 27: Rule SomethingSomething verified");
 	}
 
 	@Test
-	public void functioncall() throws Exception {
+	void functioncall() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/functioncall.cpp", "mark_cpp/functioncall.mark");
 		expected(findings, "line 9: Rule HasBeenCalled violated",
 			"line 7: Rule HasBeenCalled verified");
 	}
 
 	@Test
-	public void testNewExpression() throws Exception {
+	void testNewExpression() throws Exception {
 		var findings = performTest("mark_cpp/new.cpp", "mark_cpp/new.mark");
 		expected(findings, "line 10: Rule MustBeOne violated");
 	}
 
 	@Test
-	public void functioncallComplex() throws Exception {
+	void functioncallComplex() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/functioncall_complex.cpp", "mark_cpp/functioncall_complex.mark");
 		expected(findings,
 			"line [11, 12]: Rule Local verified",
@@ -49,7 +46,7 @@ public class MarkCppTest extends AbstractMarkTest {
 
 	@Test
 	@Disabled // requires interprocedural context-insensitive dataflow analysis for constant resolution.
-	public void _01_assign() throws Exception {
+	void _01_assign() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/01_assign.cpp", "mark_cpp/01_assign.mark");
 		System.out.println("All findings:");
 		for (Finding f : findings) {
@@ -60,7 +57,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void _02_arg() throws Exception {
+	void _02_arg() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/02_arg.cpp", "mark_cpp/02_arg.mark");
 		expected(findings,
 			"line 13: Rule NotThree violated",
@@ -69,7 +66,7 @@ public class MarkCppTest extends AbstractMarkTest {
 
 	@Test
 	@Disabled // requires interprocedural context-insensitive dataflow analysis of function argument for constant resolution.
-	public void _03_arg_as_param() throws Exception {
+	void _03_arg_as_param() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/03_arg_as_param.cpp", "mark_cpp/03_arg_as_param.mark");
 		System.out.println("All findings:");
 		for (Finding f : findings) {
@@ -80,42 +77,42 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void arg_prevassign_int() throws Exception {
+	void arg_prevassign_int() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_prevassign_int.cpp", "mark_cpp/int.mark");
 
 		expected(findings, "line 14: Rule SomethingAboutFoo violated");
 	}
 
 	@Test
-	public void arg_prevassign_bool() throws Exception {
+	void arg_prevassign_bool() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_prevassign_bool.cpp", "mark_cpp/bool.mark");
 
 		expected(findings, "line 14: Rule SomethingAboutFoo verified");
 	}
 
 	@Test
-	public void arg_prevassign_string() throws Exception {
+	void arg_prevassign_string() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_prevassign_string.cpp", "mark_cpp/string.mark");
 
 		expected(findings, "line 15: Rule SomethingAboutFoo verified");
 	}
 
 	@Test
-	public void arg_vardecl_int() throws Exception {
+	void arg_vardecl_int() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_vardecl_int.cpp", "mark_cpp/int.mark");
 
 		expected(findings, "line 12: Rule SomethingAboutFoo verified");
 	}
 
 	@Test
-	public void arg_vardecl_bool() throws Exception {
+	void arg_vardecl_bool() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_vardecl_bool.cpp", "mark_cpp/bool.mark");
 
 		expected(findings, "line 12: Rule SomethingAboutFoo verified");
 	}
 
 	@Test
-	public void arg_vardecl_string() throws Exception {
+	void arg_vardecl_string() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_vardecl_string.cpp", "mark_cpp/string.mark");
 
 		expected(findings, "line 13: Rule SomethingAboutFoo verified");
@@ -123,7 +120,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void arg_assignconstructor_int() throws Exception {
+	void arg_assignconstructor_int() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_assignconstructor_int.cpp", "mark_cpp/int.mark");
 
 		expected(findings,
@@ -131,7 +128,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void arg_assignparenthesisexpr_int() throws Exception {
+	void arg_assignparenthesisexpr_int() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_assignparenthesisexpr_int.cpp", "mark_cpp/int.mark");
 
 		System.out.println("All findings:");
@@ -145,7 +142,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void arg_initializerparenthesisexpr_int() throws Exception {
+	void arg_initializerparenthesisexpr_int() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_initializerparenthesisexpr_int.cpp", "mark_cpp/int.mark");
 
 		expected(findings,
@@ -153,7 +150,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void arg_uniforminitializer_int() throws Exception {
+	void arg_uniforminitializer_int() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/arg_uniforminitializer_int.cpp", "mark_cpp/int.mark");
 
 		expected(findings,
@@ -161,7 +158,7 @@ public class MarkCppTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void const_value() throws Exception {
+	void const_value() throws Exception {
 		Set<Finding> findings = performTest("mark_cpp/const.cpp", "mark_cpp/const.mark");
 
 		// todo: missing: Enum is not handled yet

--- a/src/test/java/de/fraunhofer/aisec/crymlin/MarkJavaTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/MarkJavaTest.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-public class MarkJavaTest extends AbstractMarkTest {
+class MarkJavaTest extends AbstractMarkTest {
 
 	@Test
 	void split_1() throws Exception {
@@ -29,7 +29,7 @@ public class MarkJavaTest extends AbstractMarkTest {
 		};
 
 		for (String expected : expectedFindings) {
-			assertTrue(1 == findings.stream().filter(f -> f.toString().equals(expected)).count(), "not found: \"" + expected + "\"");
+			assertEquals(1, findings.stream().filter(f -> f.toString().equals(expected)).count(), "not found: \"" + expected + "\"");
 			Optional<Finding> first = findings.stream().filter(f -> f.toString().equals(expected)).findFirst();
 			findings.remove(first.get());
 		}
@@ -58,7 +58,7 @@ public class MarkJavaTest extends AbstractMarkTest {
 		};
 
 		for (String expected : expectedFindings) {
-			assertTrue(1 == findings.stream().filter(f -> f.toString().equals(expected)).count(), "not found: \"" + expected + "\"");
+			assertEquals(1, findings.stream().filter(f -> f.toString().equals(expected)).count(), "not found: \"" + expected + "\"");
 			Optional<Finding> first = findings.stream().filter(f -> f.toString().equals(expected)).findFirst();
 			findings.remove(first.get());
 		}

--- a/src/test/java/de/fraunhofer/aisec/crymlin/MarkJavaTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/MarkJavaTest.java
@@ -2,21 +2,18 @@
 package de.fraunhofer.aisec.crymlin;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
 import de.fraunhofer.aisec.analysis.structures.Finding;
 
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class MarkJavaTest extends AbstractMarkTest {
 
 	@Test
-	public void split_1() throws Exception {
+	void split_1() throws Exception {
 		Set<Finding> findings = performTest("mark_java/simplesplit_splitstring.java", "mark_java/splitstring.mark");
 
 		System.out.println("All findings:");
@@ -47,7 +44,7 @@ public class MarkJavaTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void is_instance_1() throws Exception {
+	void is_instance_1() throws Exception {
 		Set<Finding> findings = performTest("mark_java/simple_instancestring.java", "mark_java/instancestring.mark");
 
 		System.out.println("All findings:");
@@ -76,7 +73,7 @@ public class MarkJavaTest extends AbstractMarkTest {
 	}
 
 	@Test
-	public void const_value() throws Exception {
+	void const_value() throws Exception {
 		Set<Finding> findings = performTest("mark_java/const.java", "mark_java/const.mark");
 
 		// todo: missing: Enum is not handled yet

--- a/src/test/java/de/fraunhofer/aisec/crymlin/MarkLoadOutputTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/MarkLoadOutputTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class MarkLoadOutputTest {
+class MarkLoadOutputTest {
 
 	private static Map<String, Mark> allModels = new HashMap<>();
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/MarkLoadOutputTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/MarkLoadOutputTest.java
@@ -7,7 +7,6 @@ import de.fraunhofer.aisec.markmodel.MEntity;
 import de.fraunhofer.aisec.markmodel.MRule;
 import de.fraunhofer.aisec.markmodel.Mark;
 import de.fraunhofer.aisec.markmodel.MarkModelLoader;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ public class MarkLoadOutputTest {
 	private static Map<String, Mark> allModels = new HashMap<>();
 
 	@BeforeAll
-	public static void startup() throws Exception {
+	public static void startup() {
 
 		URL resource = MarkLoadOutputTest.class.getClassLoader().getResource("mark/PoC_MS1/Botan_AutoSeededRNG.mark");
 		assertNotNull(resource);
@@ -54,7 +53,7 @@ public class MarkLoadOutputTest {
 	}
 
 	@Test
-	public void markModelLoaderTest() throws Exception {
+	void markModelLoaderTest() throws Exception {
 
 		for (Map.Entry<String, Mark> entry : allModels.entrySet()) {
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/OGMTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/OGMTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>
  * We expect Neo4J and OverflowDB to behave exactly the same, so we can replace one by the other. These tests verify that the graph structure is as expected.
  */
-public class OGMTest {
+class OGMTest {
 
 	private static AnalysisContext result;
 	private static AnalysisServer server;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/OGMTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/OGMTest.java
@@ -64,7 +64,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void allVerticesToNodes() throws Exception {
+	void allVerticesToNodes() {
 		var db = result.getDatabase();
 
 		// Get all vertices from graph ...
@@ -202,7 +202,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void countTranslationUnits() throws Exception {
+	void countTranslationUnits() {
 		// Get all TranslationUnitDeclarations (including subclasses)
 		GraphTraversal<Vertex, Vertex> traversal = result.getDatabase()
 				.getGraph()
@@ -216,7 +216,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void countRecordDeclarations() throws Exception {
+	void countRecordDeclarations() {
 		// Get all RecordDeclaration (including subclasses)
 		GraphTraversal<Vertex, Vertex> traversal = result.getDatabase()
 				.getGraph()
@@ -230,7 +230,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void countMethodDeclarations() throws Exception {
+	void countMethodDeclarations() {
 		// Get all MethodDeclaration (including subclasses)
 		GraphTraversal<Vertex, Vertex> traversal = result.getDatabase()
 				.getGraph()
@@ -244,7 +244,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void countEogEdges() throws Exception {
+	void countEogEdges() {
 		// Get all EOG edges
 
 		GraphTraversal<Vertex, Edge> traversal = result.getDatabase()
@@ -263,7 +263,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void retrieveAllTranslationUnits() throws Exception {
+	void retrieveAllTranslationUnits() {
 		var db = result.getDatabase();
 
 		List<TranslationUnitDeclaration> original = server.getTranslationResult().getTranslationUnits();
@@ -289,7 +289,7 @@ public class OGMTest {
 	}
 
 	@Test
-	void getContainingFunction() throws Exception {
+	void getContainingFunction() {
 		var db = result.getDatabase();
 
 		Vertex p2Start = db.getGraph().traversal().V().has("code", "p2.start(iv);").next();

--- a/src/test/java/de/fraunhofer/aisec/crymlin/OrderTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/OrderTest.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class OrderTest extends AbstractMarkTest {
 
@@ -16,7 +15,7 @@ class OrderTest extends AbstractMarkTest {
 	void checkJava() throws Exception {
 		Set<Finding> results = performTest("unittests/order.java", "unittests/order.mark");
 
-		Set<String> findings = results.stream().map(f -> f.toString()).collect(Collectors.toSet());
+		Set<String> findings = results.stream().map(Finding::toString).collect(Collectors.toSet());
 		check(findings);
 	}
 
@@ -24,7 +23,7 @@ class OrderTest extends AbstractMarkTest {
 	void checkCpp() throws Exception {
 		Set<Finding> results = performTest("unittests/order.cpp", "unittests/order.mark");
 
-		Set<String> findings = results.stream().map(f -> f.toString()).collect(Collectors.toSet());
+		Set<String> findings = results.stream().map(Finding::toString).collect(Collectors.toSet());
 		check(findings);
 	}
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/OrderTestComplex.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/OrderTestComplex.java
@@ -2,10 +2,6 @@
 package de.fraunhofer.aisec.crymlin;
 
 import de.fraunhofer.aisec.analysis.structures.Finding;
-import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
-import de.fraunhofer.aisec.crymlin.connectors.db.TraversalConnection;
-import de.fraunhofer.aisec.crymlin.dsl.CrymlinTraversalSource;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/PerformanceTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/PerformanceTest.java
@@ -6,7 +6,6 @@ import de.fraunhofer.aisec.cpg.graph.Node;
 import de.fraunhofer.aisec.cpg.helpers.Benchmark;
 import de.fraunhofer.aisec.crymlin.connectors.db.OverflowDatabase;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.jupiter.api.Disabled;
 
 import java.util.ArrayList;

--- a/src/test/java/de/fraunhofer/aisec/crymlin/RealBCTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/RealBCTest.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class RealBCTest extends AbstractMarkTest {
+class RealBCTest extends AbstractMarkTest {
 
 	@Test
 	void testSimple() throws Exception {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/RealBCTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/RealBCTest.java
@@ -5,17 +5,14 @@ import de.fraunhofer.aisec.analysis.structures.Finding;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class RealBCTest extends AbstractMarkTest {
 
 	@Test
-	public void testSimple() throws Exception {
+	void testSimple() throws Exception {
 		// Just a very simple test of a source file found in the wild.
 		Set<Finding> findings = performTest("real-examples/bc/rwedoff.Password-Manager/Main.java", "real-examples/bc/rwedoff.Password-Manager/");
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/RealBotanTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/RealBotanTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RealBotanTest extends AbstractMarkTest {
 
 	@Test
-	public void testSimple() throws Exception {
+	void testSimple() throws Exception {
 		// Just a very simple test to explore the graph
 		Set<Finding> findings = performTest("real-examples/botan/streamciphers/bsex.cpp", "real-examples/botan/streamciphers/bsex.mark");
 		GraphTraversalSource t = ctx.getDatabase()
@@ -108,7 +108,7 @@ class RealBotanTest extends AbstractMarkTest {
 		List<Finding> keyLengths = findings
 				.stream()
 				.filter(f -> f.getOnfailIdentifier().equals("BadKeyLength"))
-				.filter(f -> f.isProblem())
+				.filter(Finding::isProblem)
 				.collect(Collectors.toList());
 		assertEquals(2, keyLengths.size());
 

--- a/src/test/java/de/fraunhofer/aisec/crymlin/RealBotanTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/RealBotanTest.java
@@ -62,7 +62,7 @@ class RealBotanTest extends AbstractMarkTest {
 	}
 
 	@Test
-	@Disabled //WIP, not working yet
+	@Disabled("WIP, not working yet")
 	void testPlaybookCreator() throws Exception {
 		@NonNull
 		Set<Finding> findings = performTest("real-examples/botan/blockciphers/obraunsdorf.playbook-creator/pbcStorage.cpp",

--- a/src/test/java/de/fraunhofer/aisec/crymlin/RegressionTests.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/RegressionTests.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-public class RegressionTests extends AbstractMarkTest {
+class RegressionTests extends AbstractMarkTest {
 
 	/**
 	 * Test for arguments of NestedConstructExpressions (Java).

--- a/src/test/java/de/fraunhofer/aisec/crymlin/RegressionTests.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/RegressionTests.java
@@ -14,7 +14,7 @@ public class RegressionTests extends AbstractMarkTest {
 	 * @throws Exception
 	 */
 	@Test
-	public void testNestedConstructExpressionsJava() throws Exception {
+	void testNestedConstructExpressionsJava() throws Exception {
 		Set<Finding> findings = performTest("unittests/regression/nested_constructors/NestedConstructor.java", "unittests/regression/nested_constructors/");
 		expected(findings,
 			"line 8: Rule PublicKeyInstanceOfVerifier violated");
@@ -26,7 +26,7 @@ public class RegressionTests extends AbstractMarkTest {
 	 * @throws Exception
 	 */
 	@Test
-	public void testNestedConstructExpressionsCpp() throws Exception {
+	void testNestedConstructExpressionsCpp() throws Exception {
 		Set<Finding> findings = performTest("unittests/regression/nested_constructors/nested_constructor.cpp", "unittests/regression/nested_constructors/");
 		expected(findings,
 			"line 31: Rule PublicKeyInstanceOfVerifier violated");

--- a/src/test/java/de/fraunhofer/aisec/crymlin/StructuresTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/StructuresTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class StructuresTest {
+class StructuresTest {
 
 	@Test
 	void testConstantValueEquals() {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/StructuresTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/StructuresTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class StructuresTest {
 
 	@Test
-	public void testConstantValueEquals() {
+	void testConstantValueEquals() {
 		ConstantValue nullCV = ErrorValue.newErrorValue("narf");
 		ConstantValue otherNullCV = ErrorValue.newErrorValue("other");
 		ConstantValue oneCV = ConstantValue.of(1);

--- a/src/test/java/de/fraunhofer/aisec/crymlin/WpdsTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/WpdsTest.java
@@ -31,7 +31,7 @@ class WpdsTest extends AbstractMarkTest {
 	}
 
 	@Test
-	void testRegexToNFA() throws Exception {
+	void testRegexToNFA() {
 		XtextParser parser = new XtextParser();
 		parser.addMarkFile(new File("src/test/resources/unittests/nfa-test.mark"));
 		OrderExpression expr = (OrderExpression) parser
@@ -122,7 +122,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -138,7 +138,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -168,7 +168,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -200,7 +200,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -225,7 +225,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -251,7 +251,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -275,7 +275,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -298,7 +298,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;
@@ -317,7 +317,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA || isProblemB;
@@ -343,7 +343,7 @@ class WpdsTest extends AbstractMarkTest {
 		Map<Integer, Boolean> startLineNumbers = findings.stream()
 				.collect(Collectors.toMap(
 					f -> f.getRegions().isEmpty() ? -1 : f.getRegions().get(0).getStartLine(),
-					f -> f.isProblem(),
+						Finding::isProblem,
 					(isProblemA, isProblemB) -> {
 						System.out.println("Several findings : " + isProblemA + "/" + isProblemB);
 						return isProblemA && isProblemB;


### PR DESCRIPTION
- remove public access modifier from test classes
- remove public access modifier from test methods
- remove unused import statements
- remove throw from methods that aren't throwing exceptions
- add explanation, why some tests are disabled