### PR TITLE
Clean gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,3 @@
-val deployUsername: String? by extra // imported from settings.gradle.kts
-val deployPassword: String? by extra // imported from settings.gradle.kts
-
 plugins {
     // built-in
     java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@ plugins {
 group = "de.fraunhofer.aisec"
 
 /* License plugin needs a special treatment, as long as the main project does not have a license yet.
-   See https://github.com/hierynomus/license-gradle-plugin/issues/155 
-*/
+ * See https://github.com/hierynomus/license-gradle-plugin/issues/155
+ */
 gradle.startParameter.excludedTaskNames += "licenseMain"
 gradle.startParameter.excludedTaskNames += "licenseTest"
 
@@ -71,31 +71,37 @@ configurations.all {
 }
 
 dependencies {
-    api("org.json:json:20210307")
-
-    api("org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1")
-    api("org.apache.logging.log4j:log4j-core:2.14.1")
+    // Logging
+    implementation("org.slf4j:slf4j-api:1.8.0-beta4") // ok
     api("org.slf4j:log4j-over-slf4j:1.8.0-beta4") // needed for xtext.parser.antlr
-    api("org.slf4j:slf4j-api:1.8.0-beta4")
+    api("org.apache.logging.log4j:log4j-core:2.14.1") // impl in main; used only in test
+    runtimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1")
 
     // Code Property Graph
-    api("de.fraunhofer.aisec:cpg:3.4.0")
+    api("de.fraunhofer.aisec:cpg:3.4.0") // ok
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
-     api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { setChanging(true) }
+    api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
 
-    // LSP
-    api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0")
+    // Pushdown Systems
+    api("de.breakpointsec:pushdown:1.1") // ok
 
-    // JSON parser for generation of results file
-    api("org.json:json:20190722")
+    // LSP interface support
+    api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0") // ok
 
-    // JsonPath for querying JSON
-    api("com.jayway.jsonpath:json-path:2.5.0")
+    // Interactive console interface support using Jython (Scripting engine)
+    implementation("org.python:jython-standalone:2.7.2") // ok
 
     // Command line interface support
-    api("info.picocli:picocli:4.5.2")
+    implementation("info.picocli:picocli:4.5.2")
     annotationProcessor("info.picocli:picocli-codegen:4.5.2")
+
+    // JSON parser for generation of results file
+//    implementation("org.json:json:20190722")
+    implementation("org.json:json:20210307")
+
+    // JsonPath for querying findings description
+    implementation("com.jayway.jsonpath:json-path:2.5.0")
 
     // Gremlin
     api("org.apache.tinkerpop:gremlin-core:3.4.3")
@@ -109,15 +115,12 @@ dependencies {
     api("org.apache.tinkerpop:neo4j-gremlin:3.4.3")     // Neo4j multi-label support for gremlin
 
     // Fast in-memory graph DB (alternative to Neo4J)
-    api("io.shiftleft:overflowdb-tinkerpop3:0.128")
-    api("org.reflections", "reflections", "0.9.11")
+    implementation("io.shiftleft:overflowdb-tinkerpop3:0.128")
 
-    // Pushdown Systems
-    api("de.breakpointsec:pushdown:1.1")
+    // Reflections for OverflowDB and registering Crymlin built-ins
+    implementation("org.reflections", "reflections", "0.9.11")
 
-    // Jython (Scripting engine)
-    api("org.python:jython-standalone:2.7.2")
-
+    // Unit tests
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
@@ -125,9 +128,8 @@ dependencies {
 
 application {
     mainClass.set("de.fraunhofer.aisec.analysis.Main")
-    // Required to give Ehcache deep reflective access to fields to correctly esitmate the cache size.
-    applicationDefaultJvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED")
 }
+
 tasks.named<Test>("test") {
     useJUnitPlatform()
     maxHeapSize = "6000m"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ repositories {
         setUrl("https://oss.sonatype.org/content/groups/public")
     }
 
+    // Eclipse CDT repo
     ivy {
         setUrl("https://download.eclipse.org/tools/cdt/releases/9.11/cdt-9.11.1/plugins")
         metadataSources {
@@ -78,7 +79,7 @@ dependencies {
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1")
 
     // Code Property Graph
-    api("de.fraunhofer.aisec:cpg:3.4.0") // ok
+    api("de.fraunhofer.aisec:cpg:3.4.1") // ok
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
@@ -97,7 +98,6 @@ dependencies {
     annotationProcessor("info.picocli:picocli-codegen:4.5.2")
 
     // JSON parser for generation of results file
-//    implementation("org.json:json:20190722")
     implementation("org.json:json:20210307")
 
     // JsonPath for querying findings description
@@ -152,7 +152,6 @@ tasks.named("compileJava") {
     dependsOn(":spotlessApply")
 }
 
-
 tasks.named("sonarqube") {
     dependsOn(":jacocoTestReport")
 }
@@ -172,11 +171,4 @@ spotless {
 downloadLicenses {
     includeProjectDependencies = true
     dependencyConfiguration = "compileClasspath"
-}
-
-tasks.named<CreateStartScripts>("startScripts") {
-    doLast {
-        // workaround for https://github.com/gradle/gradle/issues/1989
-        windowsScript.writeText(windowsScript.readText().replace(Regex("set CLASSPATH=.*"), "set CLASSPATH=%APP_HOME%\\\\lib\\\\*"))
-    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,3 +172,13 @@ downloadLicenses {
     includeProjectDependencies = true
     dependencyConfiguration = "compileClasspath"
 }
+
+tasks.named<CreateStartScripts>("startScripts") {
+    doLast {
+        /* On Windows the classpath can be too long. This is a workaround for https://github.com/gradle/gradle/issues/1989
+         * 
+         * The problem doesn't seem to exist in the current version, but may reappear, so we're keeping this one around.
+         */
+        windowsScript.writeText(windowsScript.readText().replace(Regex("set CLASSPATH=.*"), "set CLASSPATH=%APP_HOME%\\\\lib\\\\*"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,1 @@
 rootProject.name = "codyze"
-
-val deployUsername: String by settings // imported by gradle.properties (set via CI, not in git!)
-val deployPassword: String by settings // imported by gradle.properties (set via CI, not in git!)


### PR DESCRIPTION
Over the time, a few properties in `build.gradle.kts` became obsolete or no longer necessary. In addition, the configurations for dependencies were tightened.