### PR TITLE
Increase method accessibility to allow tests in subpackages

### DIFF
--- a/src/test/java/de/fraunhofer/aisec/crymlin/AbstractMarkTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/AbstractMarkTest.java
@@ -39,17 +39,17 @@ public abstract class AbstractMarkTest {
 	protected AnalysisContext ctx;
 	protected TypestateMode tsMode = TypestateMode.NFA;
 
-	Set<Finding> performTest(String sourceFileName) throws Exception {
+	protected Set<Finding> performTest(String sourceFileName) throws Exception {
 		return performTest(sourceFileName, null);
 	}
 
 	@NonNull
-	Set<Finding> performTest(String sourceFileName, @Nullable String markFileName) throws Exception {
+	protected Set<Finding> performTest(String sourceFileName, @Nullable String markFileName) throws Exception {
 		return performTest(sourceFileName, null, markFileName);
 	}
 
 	@NonNull
-	Set<Finding> performTest(String sourceFileName, String[] additionalFiles, @Nullable String markFileName) throws Exception {
+	protected Set<Finding> performTest(String sourceFileName, String[] additionalFiles, @Nullable String markFileName) throws Exception {
 		ClassLoader classLoader = AbstractMarkTest.class.getClassLoader();
 
 		URL resource = classLoader.getResource(sourceFileName);


### PR DESCRIPTION
Change access modifier of test methods to protected to allow subclasses in other packages to use methods from our abstract mark test. We want to restructure unit tests in subpackages in the future.