### PR TITLE
Added support for jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-<p align="center">
-  <br>
-  <img src="https://github.com/Fraunhofer-AISEC/codyze/workflows/build/badge.svg">
-  <img src="https://img.shields.io/github/last-commit/Fraunhofer-AISEC/codyze.svg?style=popout">
-  <img src="https://sonarcloud.io/api/project_badges/measure?project=codyze&metric=security_rating">
-  <img src="https://sonarcloud.io/api/project_badges/measure?project=codyze&metric=alert_status">
-  <img src="https://sonarcloud.io/api/project_badges/measure?project=codyze&metric=coverage">
-  <a href="https://github.com/Fraunhofer-AISEC/codyze/blob/master/LICENSE"><img alt="undefined" src="https://img.shields.io/github/license/Fraunhofer-AISEC/codyze.svg?style=popout"></a>
-  <br><br><br>
-</p>
+# Codyze :mag_right: :rocket: 
+
+[![build](https://github.com/Fraunhofer-AISEC/codyze/actions/workflows/build.yml/badge.svg)](https://github.com/Fraunhofer-AISEC/codyze/actions/workflows/build.yml)
+![GitHub last commit](https://img.shields.io/github/last-commit/Fraunhofer-AISEC/codyze)
+[![](https://sonarcloud.io/api/project_badges/measure?project=codyze&metric=security_rating)](https://sonarcloud.io/summary/overall?id=codyze)
+[![](https://sonarcloud.io/api/project_badges/measure?project=codyze&metric=alert_status)](https://sonarcloud.io/summary/overall?id=codyze)
+[![](https://sonarcloud.io/api/project_badges/measure?project=codyze&metric=coverage)](https://sonarcloud.io/summary/overall?id=codyze)
+![GitHub](https://img.shields.io/github/license/Fraunhofer-AISEC/codyze)
+[![](https://jitpack.io/v/Fraunhofer-AISEC/codyze.svg)](https://jitpack.io/#Fraunhofer-AISEC/codyze)
 
 Codyze is a static code analyzer that focuses on verifying security compliance in source code, i.e. by inferring the correct use of cryptographic libraries. It operates on code property graphs and is thus able to handle non-compiling or even incomplete code fragments.
 
 Documentation: https://www.codyze.io
 
-# Build & run Codyze
+## Build & run Codyze
 
 Java 11 (OpenJDK) is a prerequisite.
 
@@ -67,14 +66,14 @@ Translation settings
 ```
 Please refer to https://www.codyze.io for further usage instructions.
 
-# Research & Student Work
+## Research & Student Work
 
 If you are looking for an exciting thesis project or student job in the field of static analysis, we are happy to discuss possible topics. Please contact us at _codyze [at] aisec.fraunhofer.de_.
 
-# Support
+## Support
 
 We will continue to maintain this project for the foreseeable future on a best-effort basis. That is, if you run into any bugs or find the documentation insufficient, we encourage you to open issues or pull requests. If you are interested in support and development for commercial use, please contact us.
 
-# License
+## License
 
 [Apache License 2.0](https://github.com/Fraunhofer-AISEC/codyze/blob/master/LICENSE)

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+jdk:
+  - openjdk11
+  


### PR DESCRIPTION
For example, to use a specific commit of Codyze as an dependency in an external project, e.g. an extension.

Succesful bunds can be found at https://jitpack.io/com/github/Fraunhofer-AISEC/codyze or http://jitpack.io/#Fraunhofer-AISEC/codyze