### PR TITLE
Update URL to update site of MARK plugin

### DIFF
--- a/docs/content/en/docs/Mark Authors/installation.md
+++ b/docs/content/en/docs/Mark Authors/installation.md
@@ -13,7 +13,7 @@ MARK is a simple domain specific language (DSL) that can be written in any text 
 ## Install the MARK Eclipse Plugin
 
 * In Eclipse, click on `Help`->`Install new software`
-* Add the update site: `https://update.breakpoint-security.com`
+* Add the update site: `https://codyze.s3.eu-central-1.amazonaws.com/codyze-mark-eclipse-plugin/`
 * Install (TODO: Name of product in eclipse update site)
 
 ## Start writing MARK policies


### PR DESCRIPTION
The documentation was still referring to an outdated update site for the MARK Eclipse plugin. This PR updates the URL in the docs. 

As a side effect:
The update site itself was updates as well.

fixes #193 