### PR TITLE
Add builtin _split_subset

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitSubset.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitSubset.java
@@ -1,0 +1,81 @@
+
+package de.fraunhofer.aisec.crymlin.builtin;
+
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionEvaluator;
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionHelper;
+import de.fraunhofer.aisec.analysis.structures.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+/**
+ * Method signature: _split_subset(String str, String splitter, List superset)
+ * <p>
+ * This Builtin behaves like superset.containsAll(str.split(splitter)).
+ * <p>
+ * In case of an error, this Builtin returns an ErrorValue;
+ */
+public class SplitSubset implements Builtin {
+	private static final Logger log = LoggerFactory.getLogger(SplitSubset.class);
+
+	@NonNull
+	@Override
+	public String getName() {
+		return "_split_subset";
+	}
+
+	@Override
+	public ConstantValue execute(
+			@NonNull AnalysisContext ctx,
+			@NonNull ListValue argResultList,
+			@NonNull Integer contextID,
+			@NonNull MarkContextHolder markContextHolder,
+			@NonNull ExpressionEvaluator expressionEvaluator) {
+
+		// arguments: String, String, List
+		// example:
+		// _split_subset("ASD/EFG/JKL", "/", ["ASD", "EFG", "JKL", "MNO"]) returns true
+		String regex = "";
+
+		try {
+			BuiltinHelper.verifyArgumentTypesOrThrow(argResultList, ConstantValue.class, ConstantValue.class, ListValue.class);
+
+			String s = ExpressionHelper.asString(argResultList.get(0));
+			regex = ExpressionHelper.asString(argResultList.get(1));
+			var listSet = new HashSet<>(((ListValue) argResultList.get(2)).getAll());
+
+			var whitelist = listSet.stream().map(mir -> ((ConstantValue) mir).getValue()).collect(Collectors.toSet());
+
+			if (s == null || regex == null || whitelist == null) {
+				log.warn("One of the arguments for _split_subset was not the expected type, or not initialized/resolved");
+				return ErrorValue.newErrorValue("One of the arguments for _split_subset was not the expected type, or not initialized/resolved", argResultList.getAll());
+			}
+
+			log.info("args are: {}; {}; {}", s, regex, whitelist);
+
+			String[] splitted = s.split(regex);
+			var values = Set.of(splitted);
+			boolean isWhitelisted = whitelist.containsAll(values);
+
+			ConstantValue cv = ConstantValue.of(isWhitelisted);
+
+			cv.addResponsibleVerticesFrom((ConstantValue) argResultList.get(0),
+				(ConstantValue) argResultList.get(1));
+
+			return cv;
+		}
+		catch (PatternSyntaxException e) {
+			log.warn("Pattern for _split_subset wrong: '{}': {}", regex, e.getMessage());
+			return ErrorValue.newErrorValue(String.format("Pattern for _split_subset wrong: '%s': %s", regex, e.getMessage()), argResultList.getAll());
+		}
+		catch (InvalidArgumentException e) {
+			log.warn(e.getMessage());
+			return ErrorValue.newErrorValue(e.getMessage(), argResultList.getAll());
+		}
+	}
+}

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
@@ -189,4 +189,15 @@ class BuiltInTest extends AbstractMarkTest {
 
 	}
 
+	@Test
+	void testSplitSubset() throws Exception {
+		var findings = performTest("builtins/split_subset.c", "builtins/split_subset.mark");
+
+		expected(findings,
+			"line 2: Rule split_subset_1 verified",
+			"line 2: Rule split_subset_2 verified",
+			"line 2: Rule split_subset_3 verified",
+			"line 2: Rule split_subset_4 violated");
+	}
+
 }

--- a/src/test/resources/builtins/split_subset.c
+++ b/src/test/resources/builtins/split_subset.c
@@ -1,0 +1,3 @@
+int main() {
+    test("c1:c2");
+}

--- a/src/test/resources/builtins/split_subset.mark
+++ b/src/test/resources/builtins/split_subset.mark
@@ -1,0 +1,42 @@
+package split_subset
+
+entity E {
+	var param;
+
+	op t {
+		test(param);
+	}
+
+}
+
+rule split_subset_1 {
+    using
+    	E as e
+    ensure
+        _split_subset(e.param, ":", ["c1", "c2"])
+    onfail success
+}
+
+rule split_subset_2 {
+    using
+        E as e
+    ensure
+        _split_subset(e.param, ":", ["c1", "c2"]) == true
+    onfail success
+}
+
+rule split_subset_3 {
+    using
+        E as e
+    ensure
+        _split_subset(e.param, ":", ["c1", "c2", "c3"])
+    onfail success
+}
+
+rule split_subset_4 {
+    using
+        E as e
+    ensure
+        _split_subset(e.param, ":", ["c1"])
+    onfail fail
+}


### PR DESCRIPTION
_split_subset is a new builtin. It takes a string, splits with a given regex and checks if the resulting elements are all contained in the list specified as third argument.

This builtin helps to analyze arguments, where each part must be whitelisted.

See test case for an example.


Different solution for #201: Instead of creating results with list values, the check against a list is included in this builtin.
