### PR TITLE
Resolve base of declared reference expressions when finding MARK operand bases

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/crymlin/CrymlinQueryWrapper.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/CrymlinQueryWrapper.java
@@ -849,11 +849,18 @@ public class CrymlinQueryWrapper {
 		}
 
 		// now calculate a list of contextID to matching vertices which fill the base we are looking for
-
 		for (CPGVertexWithValue vertexWithValue : vertices) {
 			Long id = -1L; // -1 = null
 			if (vertexWithValue.getBase() != null) {
-				id = (Long) vertexWithValue.getBase().id();
+				var base = vertexWithValue.getBase();
+
+				if (base.property("nodeType").isPresent()
+						&& base.value("nodeType").equals("de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression")) {
+					var referencedBase = base.edges(Direction.OUT, "REFERS_TO").next().inVertex();
+					id = (Long) referencedBase.id();
+				} else {
+					id = (Long) base.id();
+				}
 			}
 			List<Integer> contextIDs = nodeIDToContextIDs.get(id);
 			if (contextIDs == null) {

--- a/src/main/java/de/fraunhofer/aisec/crymlin/CrymlinQueryWrapper.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/CrymlinQueryWrapper.java
@@ -833,7 +833,6 @@ public class CrymlinQueryWrapper {
 			}
 		} else {
 			// if the instance is entity referenced in the op, precalculate the variabledecl for each used op
-
 			for (Map.Entry<Integer, MarkContext> entry : context.getAllContexts().entrySet()) {
 				if (!entry.getValue().getInstanceContext().containsInstance(instance)) {
 					log.warn("Instance not found in context");
@@ -927,12 +926,42 @@ public class CrymlinQueryWrapper {
 		return false;
 	}
 
+	/**
+	 *
+	 * TODO if there are really more than one possible DFG targets we should return a list
+	 *
+	 * @param vertex
+	 * @return
+	 */
 	public static Optional<Vertex> getDFGTarget(Vertex vertex) {
 		Iterator<Edge> it = vertex.edges(Direction.OUT, DFG);
-		if (it.hasNext()) {
-			return Optional.of(it.next().inVertex());
+
+		var target = Optional.<Vertex> empty();
+
+		// there are cases where there is more than one outgoing DFG edge
+		while (it.hasNext()) {
+			var e = it.next();
+			var v = e.inVertex();
+
+			log.info("DFG target: {}", v);
+
+			// set the first find
+			if (target.isEmpty()) {
+				target = Optional.of(v);
+			} else {
+				// otherwise, look for something more useful
+				if (v.property("nodeType").isPresent()) {
+					var nodeType = v.value("nodeType");
+
+					// like a declared reference expression or a variable declaration
+					if (nodeType.equals("de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression")
+							|| nodeType.equals("de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration")) {
+						target = Optional.of(v);
+					}
+				}
+			}
 		}
-		return Optional.empty();
+		return target;
 	}
 
 	public static Set<Vertex> getDFGSources(Vertex vertex) {

--- a/src/test/java/de/fraunhofer/aisec/crymlin/CTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/CTest.java
@@ -1,0 +1,19 @@
+
+package de.fraunhofer.aisec.crymlin;
+
+import org.junit.jupiter.api.Test;
+
+class CTest extends AbstractMarkTest {
+
+	@Test
+	void testDefinition() throws Exception {
+		var findings = performTest("c/def.c", "c/s.mark");
+		containsFindings(findings, "line 14: Rule some_s verified");
+	}
+
+	@Test
+	void testDeclAssign() throws Exception {
+		var findings = performTest("c/declassign.c", "c/s.mark");
+		containsFindings(findings, "line 16: Rule some_s verified");
+	}
+}

--- a/src/test/resources/c/declassign.c
+++ b/src/test/resources/c/declassign.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+struct s {
+    int a;
+};
+
+
+struct s * S_new(int a) {
+    struct s *s = malloc(sizeof(struct s));
+    s->a = a;
+    return s;
+}
+
+void fun() {
+    struct s *s_ptr;
+    s_ptr = S_new(1);
+}

--- a/src/test/resources/c/def.c
+++ b/src/test/resources/c/def.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+struct s {
+    int a;
+};
+
+struct s * S_new(int a) {
+    struct s *s = malloc(sizeof(struct s));
+    s->a = a;
+    return s;
+}
+
+void fun() {
+    struct s *s_ptr = S_new(1);
+}

--- a/src/test/resources/c/s.mark
+++ b/src/test/resources/c/s.mark
@@ -1,0 +1,16 @@
+package test
+
+entity S {
+    var a;
+
+    op new {
+        this = S_new(a);
+    }
+}
+
+rule some_s {
+    using S as s
+    ensure
+        s.a > 0
+    onfail test
+}


### PR DESCRIPTION
This adds an additional step when resolving MARK operands. Operands might be associated to declared reference expression. The MARK entity of the operand might, however, be associated to a variable declaration. Previously, the declared reference expression did not resolve to the variable declaration. As a result, Codyze could not resolve a base. This change now resolves to the referenced declaration.

Closes #216 