### PR TITLE
Add builtin split and disjoint

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitDisjoint.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitDisjoint.java
@@ -1,0 +1,84 @@
+
+package de.fraunhofer.aisec.crymlin.builtin;
+
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionEvaluator;
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionHelper;
+import de.fraunhofer.aisec.analysis.structures.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+
+/**
+ * Method signature: _split_disjoint(String str, String splitter, List set)
+ * <p>
+ * This Builtin splits the str and checks, if any of the resulting elements is part of the provided set.
+ * <p>
+ * In case of an error, this Builtin returns an ErrorValue;
+ */
+public class SplitDisjoint implements Builtin {
+	private static final Logger log = LoggerFactory.getLogger(SplitDisjoint.class);
+
+	@NonNull
+	@Override
+	public String getName() {
+		return "_split_disjoint";
+	}
+
+	@Override
+	public ConstantValue execute(
+			@NonNull AnalysisContext ctx,
+			@NonNull ListValue argResultList,
+			@NonNull Integer contextID,
+			@NonNull MarkContextHolder markContextHolder,
+			@NonNull ExpressionEvaluator expressionEvaluator) {
+
+		// arguments: String, String, List
+		// example:
+		// _split_disjoint("ASD/EFG/JKL", "/", ["ABC", "EFG", "JKL"]) returns true
+		String regex = "";
+
+		try {
+			BuiltinHelper.verifyArgumentTypesOrThrow(argResultList, ConstantValue.class, ConstantValue.class, ListValue.class);
+
+			String s = ExpressionHelper.asString(argResultList.get(0));
+			regex = ExpressionHelper.asString(argResultList.get(1));
+			var listSet = new HashSet<>(((ListValue) argResultList.get(2)).getAll());
+
+			var providedSet = listSet.stream().map(mir -> ((ConstantValue) mir).getValue()).collect(Collectors.toSet());
+
+			if (s == null || regex == null || providedSet == null) {
+				log.warn("One of the arguments for _split_match_unordered was not the expected type, or not initialized/resolved");
+				return ErrorValue.newErrorValue("One of the arguments for _split_match_unordered was not the expected type, or not initialized/resolved",
+					argResultList.getAll());
+			}
+
+			log.info("args are: {}; {}; {}", s, regex, providedSet);
+
+			String[] splitted = s.split(regex);
+			var values = Set.of(splitted);
+			boolean isDisjoint = Collections.disjoint(values, providedSet);
+
+			ConstantValue cv = ConstantValue.of(isDisjoint);
+
+			cv.addResponsibleVerticesFrom((ConstantValue) argResultList.get(0),
+				(ConstantValue) argResultList.get(1));
+
+			return cv;
+		}
+		catch (PatternSyntaxException e) {
+			log.warn("Pattern for _split_disjoint wrong: '{}': {}", regex, e.getMessage());
+			return ErrorValue.newErrorValue(String.format("Pattern for _split_disjoint wrong: '%s': %s", regex, e.getMessage()), argResultList.getAll());
+		}
+		catch (InvalidArgumentException e) {
+			log.warn(e.getMessage());
+			return ErrorValue.newErrorValue(e.getMessage(), argResultList.getAll());
+		}
+	}
+}

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
@@ -202,4 +202,13 @@ class BuiltInTest extends AbstractMarkTest {
 			"line 2: Rule split_match_unordered_6 violated");
 	}
 
+	@Test
+	void testSplitDisjoint() throws Exception {
+		var findings = performTest("builtins/split_disjoint.c", "builtins/split_disjoint.mark");
+
+		expected(findings,
+			"line 2: Rule split_disjoint_1 verified",
+			"line 2: Rule split_disjoint_2 verified",
+			"line 2: Rule split_disjoint_3 violated");
+	}
 }

--- a/src/test/resources/builtins/split_disjoint.c
+++ b/src/test/resources/builtins/split_disjoint.c
@@ -1,0 +1,3 @@
+int main() {
+    test("c1:c2");
+}

--- a/src/test/resources/builtins/split_disjoint.mark
+++ b/src/test/resources/builtins/split_disjoint.mark
@@ -1,0 +1,34 @@
+package split_subset
+
+entity E {
+	var param;
+
+	op t {
+		test(param);
+	}
+
+}
+
+rule split_disjoint_1 {
+    using
+    	E as e
+    ensure
+        _split_disjoint(e.param, ":", ["c3", "c4"])
+    onfail success
+}
+
+rule split_disjoint_2 {
+    using
+        E as e
+    ensure
+        _split_disjoint(e.param, ":", ["c3", "c4"]) == true
+    onfail success
+}
+
+rule split_disjoint_3 {
+    using
+        E as e
+    ensure
+        _split_disjoint(e.param, ":", ["c1", "c3"])
+    onfail fail
+}


### PR DESCRIPTION
It takes as the first argument a string, splits it using the string of the second argument and checks, if the resulting list of elements is
disjoint from the list provided as third argument.

This builtin becomes useful if one wants to check that some options/configurations are not set.