### PR TITLE
Remove whitespaces on spitted strings

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitDisjoint.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitDisjoint.java
@@ -8,10 +8,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
@@ -54,15 +51,15 @@ public class SplitDisjoint implements Builtin {
 			var providedSet = listSet.stream().map(mir -> ((ConstantValue) mir).getValue()).collect(Collectors.toSet());
 
 			if (s == null || regex == null || providedSet == null) {
-				log.warn("One of the arguments for _split_match_unordered was not the expected type, or not initialized/resolved");
-				return ErrorValue.newErrorValue("One of the arguments for _split_match_unordered was not the expected type, or not initialized/resolved",
+				log.warn("One of the arguments for _split_disjoint was not the expected type, or not initialized/resolved");
+				return ErrorValue.newErrorValue("One of the arguments for _split_disjoint was not the expected type, or not initialized/resolved",
 					argResultList.getAll());
 			}
 
 			log.info("args are: {}; {}; {}", s, regex, providedSet);
 
 			String[] splitted = s.split(regex);
-			var values = Set.of(splitted);
+			var values = Arrays.stream(splitted).map(String::strip).collect(Collectors.toSet());
 			boolean isDisjoint = Collections.disjoint(values, providedSet);
 
 			ConstantValue cv = ConstantValue.of(isDisjoint);

--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitDisjoint.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitDisjoint.java
@@ -8,7 +8,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 

--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitMatchUnordered.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitMatchUnordered.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 

--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitMatchUnordered.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/SplitMatchUnordered.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -69,7 +70,7 @@ public class SplitMatchUnordered implements Builtin {
 			log.info("args are: {}; {}; {}; {}", s, regex, providedSet, strict);
 
 			String[] splitted = s.split(regex);
-			var values = Set.of(splitted);
+			var values = Arrays.stream(splitted).map(String::strip).collect(Collectors.toSet());
 			boolean isMatch = strict ? Objects.equals(values, providedSet) : providedSet.containsAll(values);
 
 			ConstantValue cv = ConstantValue.of(isMatch);


### PR DESCRIPTION
Java's `String.split()` removes only trailing whitespaces. With the various `_split_*` it's easier to remove trailing and leading whitespaces. This simplifies the required regex for the splitting.