### PR TITLE
Adds builtin `_now()` and `_year()`

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/Builtin.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/Builtin.java
@@ -23,6 +23,10 @@ public interface Builtin {
 	@NonNull
 	String getName();
 
+	default boolean hasParameters() {
+		return true;
+	}
+
 	/**
 	 * Runs this Builtin.
 	 *

--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/Now.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/Now.java
@@ -1,0 +1,58 @@
+
+package de.fraunhofer.aisec.crymlin.builtin;
+
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionEvaluator;
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionHelper;
+import de.fraunhofer.aisec.analysis.structures.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Method signature: _now()
+ *
+ * <p>
+ * Relies on Java's {@link Instant#now()}.
+ * </p>
+ *
+ * Note:
+ * Time is represented as numeric value. The value represents the number of seconds
+ * since epoch (1970-01-01T00:00:00Z).
+ */
+public class Now implements Builtin {
+	private static final Logger log = LoggerFactory.getLogger(Now.class);
+
+	@NonNull
+	@Override
+	public String getName() {
+		return "_now";
+	}
+
+	@NonNull
+	@Override
+	public boolean hasParameters() {
+		return false;
+	}
+
+	@NonNull
+	@Override
+	public ConstantValue execute(
+			@NonNull AnalysisContext ctx,
+			@NonNull ListValue argResultList,
+			@NonNull Integer contextID,
+			@NonNull MarkContextHolder markContextHolder,
+			@NonNull ExpressionEvaluator expressionEvaluator) {
+
+		log.debug("Executing builtin: {}", this.getName());
+
+		var instant = Instant.now();
+		var epochSeconds = instant.getEpochSecond();
+
+		log.debug("_now() -> {}", epochSeconds);
+
+		return ConstantValue.of(epochSeconds);
+	}
+}

--- a/src/main/java/de/fraunhofer/aisec/crymlin/builtin/Year.java
+++ b/src/main/java/de/fraunhofer/aisec/crymlin/builtin/Year.java
@@ -1,0 +1,76 @@
+
+package de.fraunhofer.aisec.crymlin.builtin;
+
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionEvaluator;
+import de.fraunhofer.aisec.analysis.markevaluation.ExpressionHelper;
+import de.fraunhofer.aisec.analysis.structures.*;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalField;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Method signature: _year()
+ *
+ * Note:
+ * Time is represented as numeric value. The value represents the number of seconds
+ * since epoch (1970-01-01T00:00:00Z).
+ */
+public class Year implements Builtin {
+	private static final Logger log = LoggerFactory.getLogger(Year.class);
+
+	@NonNull
+	@Override
+	public String getName() {
+		return "_year";
+	}
+
+	@NonNull
+	@Override
+	public ConstantValue execute(
+			@NonNull AnalysisContext ctx,
+			@NonNull ListValue argResultList,
+			@NonNull Integer contextID,
+			@NonNull MarkContextHolder markContextHolder,
+			@NonNull ExpressionEvaluator expressionEvaluator) {
+
+		// arguments: int
+		// example:
+		// _year(_now()) returns 2021
+
+		try {
+			BuiltinHelper.verifyArgumentTypesOrThrow(argResultList, ConstantValue.class);
+
+			var epochSeconds = ExpressionHelper.asNumber(argResultList.get(0));
+
+			if (epochSeconds == null) {
+				log.warn("The argument for _year was not the expected type, or not initialized/resolved");
+				return ErrorValue.newErrorValue("The argument for _year was not the expected type, or not initialized/resolved", argResultList.getAll());
+			}
+
+			log.info("arg: {}", epochSeconds);
+
+			var instant = Instant.ofEpochSecond((Long) epochSeconds);
+			var ldt = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+			var year = ldt.getYear();
+
+			log.debug("_year() -> {}", year);
+
+			ConstantValue cv = ConstantValue.of(year);
+			cv.addResponsibleVerticesFrom((ConstantValue) argResultList.get(0));
+
+			return cv;
+		}
+		catch (InvalidArgumentException e) {
+			log.warn(e.getMessage());
+			return ErrorValue.newErrorValue(e.getMessage(), argResultList.getAll());
+		}
+	}
+}

--- a/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
+++ b/src/test/java/de/fraunhofer/aisec/crymlin/BuiltInTest.java
@@ -211,4 +211,20 @@ class BuiltInTest extends AbstractMarkTest {
 			"line 2: Rule split_disjoint_2 verified",
 			"line 2: Rule split_disjoint_3 violated");
 	}
+
+	@Test
+	void testNow() throws Exception {
+		var findings = performTest("builtins/now.c", "builtins/now.mark");
+
+		expected(findings,
+			"line []: Rule Test verified");
+	}
+
+	@Test
+	void testYear() throws Exception {
+		var findings = performTest("builtins/year.c", "builtins/year.mark");
+
+		expected(findings,
+			"line []: Rule Test verified");
+	}
 }

--- a/src/test/resources/builtins/now.c
+++ b/src/test/resources/builtins/now.c
@@ -1,0 +1,3 @@
+int main() {
+    test("a");
+}

--- a/src/test/resources/builtins/now.mark
+++ b/src/test/resources/builtins/now.mark
@@ -1,0 +1,18 @@
+package builtin
+
+entity T {
+    var v;
+
+    op top {
+        test(v);
+    }
+}
+
+rule Test {
+    using T as t
+    when
+        t.v == "a"
+    ensure
+        _year(_now()) >= 2021
+    onfail failure
+}

--- a/src/test/resources/builtins/year.c
+++ b/src/test/resources/builtins/year.c
@@ -1,0 +1,3 @@
+int main() {
+    test("a");
+}

--- a/src/test/resources/builtins/year.mark
+++ b/src/test/resources/builtins/year.mark
@@ -1,0 +1,18 @@
+package builtin
+
+entity T {
+    var v;
+
+    op top {
+        test(v);
+    }
+}
+
+rule Test {
+    using T as t
+    when
+        t.v == "a"
+    ensure
+        _year(0) == 1970
+    onfail failure
+}


### PR DESCRIPTION
Builtin `_now()` returns the current time at execution as seconds since epoch -- 1970-01-01T00:00:00Z.

Builtin `_year()` takes an integer argument, interprets it as seconds since epoch and returns the current year.

`_now()` and `_year()` can be used in conjunction to create time dependent rules. For instance, one can write rules that are valid for a predetermined number of years. Afterwards, these rules are considered obsolete.

To implement zero parameter builtins, `Builtin` was retrofitted with a flag to indicate whether it has parameters.