### PR TITLE
Prepare 2.0.0-beta.1 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     // Code Property Graph
     //api("de.fraunhofer.aisec:cpg:3.5.1") // ok
     //implementation("com.github.Fraunhofer-AISEC:cpg:v4.0.0-beta.1")
-    implementation("com.github.Fraunhofer-AISEC:cpg:bbc1906dc")
+    implementation("com.github.Fraunhofer-AISEC:cpg:4.0.0-beta.2")
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok


### PR DESCRIPTION
We are using the CPG 4.0.0-beta.2 for this one.