### PR TITLE
Changed branch of MARK repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
-    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:main-SNAPSHOT:repackaged")
+    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:73209e5df:repackaged") // pin to specific commit before annotations
 
     // Pushdown Systems
     api("de.breakpointsec:pushdown:1.1") // ok

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,7 @@ dependencies {
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
-    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:master-SNAPSHOT:repackaged")
+    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:main-SNAPSHOT:repackaged")
 
     // Pushdown Systems
     api("de.breakpointsec:pushdown:1.1") // ok


### PR DESCRIPTION
It changed from `master` to `main`. I think In the future, we should consider using a tagged release.

Update: it seems that annotation support breaks Codyze. So for now, I will pin it to a specific commit pre-annotations