### PR TITLE
Refactor builtin's execute method for wider return types

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java
@@ -482,7 +482,7 @@ public class ExpressionEvaluator {
 					result.put(entry.getKey(), cv);
 				}
 			} else {
-				MarkIntermediateResult cv = builtin.get().execute(resultCtx, new ListValue(), -1, markContextHolder, this);
+				var cv = builtin.get().execute(resultCtx, new ListValue(), -1, markContextHolder, this);
 				result.put(0, cv);
 			}
 			return result;

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java
@@ -478,7 +478,7 @@ public class ExpressionEvaluator {
 						continue;
 					}
 
-					MarkIntermediateResult cv = builtin.get().execute(resultCtx, (ListValue) (entry.getValue()), entry.getKey(), markContextHolder, this);
+					var cv = builtin.get().execute(resultCtx, (ListValue) (entry.getValue()), entry.getKey(), markContextHolder, this);
 					result.put(entry.getKey(), cv);
 				}
 			} else {

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluator.java
@@ -478,11 +478,11 @@ public class ExpressionEvaluator {
 						continue;
 					}
 
-					ConstantValue cv = builtin.get().execute(resultCtx, (ListValue) (entry.getValue()), entry.getKey(), markContextHolder, this);
+					MarkIntermediateResult cv = builtin.get().execute(resultCtx, (ListValue) (entry.getValue()), entry.getKey(), markContextHolder, this);
 					result.put(entry.getKey(), cv);
 				}
 			} else {
-				ConstantValue cv = builtin.get().execute(resultCtx, new ListValue(), -1, markContextHolder, this);
+				MarkIntermediateResult cv = builtin.get().execute(resultCtx, new ListValue(), -1, markContextHolder, this);
 				result.put(0, cv);
 			}
 			return result;

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Between.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Between.java
@@ -28,7 +28,7 @@ public class Between implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Builtin.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Builtin.java
@@ -1,6 +1,7 @@
 
 package de.fraunhofer.aisec.codyze.crymlin.builtin;
 
+import de.fraunhofer.aisec.codyze.analysis.MarkIntermediateResult;
 import de.fraunhofer.aisec.codyze.analysis.markevaluation.ExpressionEvaluator;
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext;
 import de.fraunhofer.aisec.codyze.analysis.resolution.ConstantValue;
@@ -39,7 +40,7 @@ public interface Builtin {
 	 * @param expressionEvaluator the expressionEvaluator, this builtin is called from
 	 * @return
 	 */
-	ConstantValue execute(
+	MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/ConstValue.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/ConstValue.java
@@ -24,7 +24,7 @@ public class ConstValue implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/DirectEogConnection.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/DirectEogConnection.java
@@ -23,7 +23,7 @@ public class DirectEogConnection implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/EogConnection.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/EogConnection.java
@@ -22,7 +22,7 @@ public class EogConnection implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/GetCode.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/GetCode.java
@@ -26,7 +26,7 @@ public class GetCode implements Builtin {
 		return "_get_code";
 	}
 
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/HasValue.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/HasValue.java
@@ -23,7 +23,7 @@ public class HasValue implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/InsideSameFunction.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/InsideSameFunction.java
@@ -23,7 +23,7 @@ public class InsideSameFunction implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Is.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Is.java
@@ -1,6 +1,7 @@
 
 package de.fraunhofer.aisec.codyze.crymlin.builtin;
 
+import de.fraunhofer.aisec.codyze.analysis.MarkIntermediateResult;
 import de.fraunhofer.aisec.codyze.analysis.markevaluation.ExpressionEvaluator;
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext;
 import de.fraunhofer.aisec.codyze.analysis.resolution.ConstantValue;
@@ -23,7 +24,7 @@ public class Is implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/IsInstance.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/IsInstance.java
@@ -32,7 +32,7 @@ public class IsInstance implements Builtin {
 		return "_is_instance";
 	}
 
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Length.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Length.java
@@ -26,7 +26,7 @@ public class Length implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Now.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Now.java
@@ -2,6 +2,7 @@
 package de.fraunhofer.aisec.codyze.crymlin.builtin;
 
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext;
+import de.fraunhofer.aisec.codyze.analysis.MarkIntermediateResult;
 import de.fraunhofer.aisec.codyze.analysis.resolution.ConstantValue;
 import de.fraunhofer.aisec.codyze.analysis.ListValue;
 import de.fraunhofer.aisec.codyze.analysis.MarkContextHolder;
@@ -38,9 +39,8 @@ public class Now implements Builtin {
 		return false;
 	}
 
-	@NonNull
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/ReceivesValueFrom.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/ReceivesValueFrom.java
@@ -27,7 +27,7 @@ public class ReceivesValueFrom implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Split.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Split.java
@@ -28,7 +28,7 @@ public class Split implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/SplitDisjoint.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/SplitDisjoint.java
@@ -32,7 +32,7 @@ public class SplitDisjoint implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/SplitMatchUnordered.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/SplitMatchUnordered.java
@@ -34,7 +34,7 @@ public class SplitMatchUnordered implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/StartsWith.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/StartsWith.java
@@ -26,7 +26,7 @@ public class StartsWith implements Builtin {
 	}
 
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Year.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/builtin/Year.java
@@ -29,9 +29,8 @@ public class Year implements Builtin {
 		return "_year";
 	}
 
-	@NonNull
 	@Override
-	public ConstantValue execute(
+	public MarkIntermediateResult execute(
 			@NonNull AnalysisContext ctx,
 			@NonNull ListValue argResultList,
 			@NonNull Integer contextID,


### PR DESCRIPTION
Previously, builtin's execute method was limited to ConstantValue. This meant that builtins could only return booleans, numbers or strings. It wasn't possible to return lists. This was an undue limitation on the possibilities of builtins.

This refactors the return type of execute to the more general MarkIntermediateResult. This should allow to return ListValue for further processing.