### PR TITLE
Consistently using `getSuitableDFGTarget` to find suitable DFG target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,12 @@ sourceSets.configureEach {
     }
 }
 
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+    }
+}
+
 // Added mark files from dist folder to test resources
 sourceSets.getByName("test").resources {
     srcDir("src/dist")

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/EvaluationHelper.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/EvaluationHelper.kt
@@ -127,12 +127,6 @@ fun Node.getSuitableDFGTarget(): Node? {
             }
             .sortedWith(Comparator.comparing(Node::name))
 
-    if (suitable.size > 1) {
-        log.warn(
-            "We still have more than one suitable DFG edges coming from {}. We are taking the first one, but this might lead to incorrect results."
-        )
-    }
-
     return suitable.firstOrNull()
 }
 

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/OrderNFAEvaluator.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/OrderNFAEvaluator.java
@@ -198,7 +198,7 @@ public class OrderNFAEvaluator {
 							} else if (vertex instanceof ConstructExpression) { // ctor
 								var initializerBase = getAstParent(vertex);
 								if (initializerBase != null) {
-									var next = getSuitableDFGTarget(vertex);
+									var next = getSuitableDFGTarget(initializerBase);
 									if (next != null) {
 										base = next.getName();
 										// for ctor, the DFG points already to the variabledecl

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/OrderNFAEvaluator.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/OrderNFAEvaluator.java
@@ -201,10 +201,19 @@ public class OrderNFAEvaluator {
 									var next = getSuitableDFGTarget(initializerBase);
 									if (next != null) {
 										base = next.getName();
-										// for ctor, the DFG points already to the variabledecl
-										// TODO: not true, it can also be a reference
-										refNode = next;
-										ref = refNode.getId().toString();
+
+										if (next instanceof VariableDeclaration) {
+											// this is already the reference
+											refNode = next;
+											ref = refNode.getId().toString();
+										} else {
+											if (next instanceof DeclaredReferenceExpression) {
+												refNode = ((DeclaredReferenceExpression) next).getRefersTo();
+												if (refNode != null) {
+													ref = refNode.getId().toString();
+												}
+											}
+										}
 									}
 								}
 							} else {

--- a/src/test/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluatorTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/ExpressionEvaluatorTest.kt
@@ -78,7 +78,8 @@ class ExpressionEvaluatorTest : AbstractTest() {
         val evaluator = Evaluator(mark, ServerConfiguration.builder().build())
 
         // Let's provide the list of entities and nodes, this is normally done by
-        // findInstancesForEntities. In this case, we simply point it towards our variable declaration
+        // findInstancesForEntities. In this case, we simply point it towards our variable
+        // declaration
         val entities = listOf(listOf(Pair("a", a)))
 
         val markContextHolder = evaluator.createMarkContext(entities)

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/RealBCTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/RealBCTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertEquals
 import org.junit.jupiter.api.*
 
 // at least it breaks consistently now
-@Disabled
 internal class RealBCTest : AbstractMarkTest() {
     @Test
     @Throws(Exception::class)


### PR DESCRIPTION
Also corrected an issue in the order evaluator, where the target of a wrong node was used (`vertex` instead of `initializerBase`). This also fixes all issues with the `RealBCTest`, which is now re-enabled.

Fixes #260