### PR TITLE
Update MARK to pull in annotation feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
-    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:b1d6332b35:repackaged") // pin to specific commit before annotations
+    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:bbd54a7b11:repackaged") // pin to specific commit before annotations
 
     // Pushdown Systems
     api("de.breakpointsec:pushdown:1.1") // ok

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
-    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:73209e5df:repackaged") // pin to specific commit before annotations
+    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:b1d6332b35:repackaged") // pin to specific commit before annotations
 
     // Pushdown Systems
     api("de.breakpointsec:pushdown:1.1") // ok


### PR DESCRIPTION
The latest MARK version support annotations. This PR pulls in the new version of MARK unsing jitpack.io.