### PR TITLE
Bump VSCode engine and types

### DIFF
--- a/plugins/vscode/include_codyze.sh
+++ b/plugins/vscode/include_codyze.sh
@@ -1,5 +1,5 @@
 #/bin/bash
 rm -rf codyze*
-cp ../build/distributions/codyze*.zip .
+cp ../../build/distributions/codyze*.zip .
 unzip codyze*.zip
 mv codyze*/ codyze || true

--- a/plugins/vscode/package-lock.json
+++ b/plugins/vscode/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@types/mocha": "9.0.0",
 				"@types/node": "14.17.19",
-				"@types/vscode": "1.57.0",
+				"@types/vscode": "^1.60.0",
 				"@typescript-eslint/parser": "4.31.2",
 				"eslint": "7.32.0",
 				"mocha": "9.1.2",
@@ -24,7 +24,7 @@
 				"webpack-cli": "4.8.0"
 			},
 			"engines": {
-				"vscode": "^1.57.0"
+				"vscode": "^1.60.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -259,9 +259,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-			"integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
+			"integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -3513,9 +3513,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-			"integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
+			"integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
 			"dev": true
 		},
 		"@typescript-eslint/parser": {

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -11,7 +11,7 @@
 	"publisher": "fraunhofer-aisec",
 	"categories": [],
 	"engines": {
-		"vscode": "^1.57.0"
+		"vscode": "^1.60.0"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^7.0.0"
@@ -55,7 +55,7 @@
 	"devDependencies": {
 		"@types/mocha": "9.0.0",
 		"@types/node": "14.17.19",
-		"@types/vscode": "1.57.0",
+		"@types/vscode": "^1.60.0",
 		"@typescript-eslint/parser": "4.31.2",
 		"eslint": "7.32.0",
 		"mocha": "9.1.2",


### PR DESCRIPTION
Bumping the version for VSCode engine and `@types/vscode` to the same version. 

The hope is that this also enables renovate to update both simultaneously.