### PR TITLE
Reconfigure version range for vscode

### DIFF
--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -11,7 +11,7 @@
 	"publisher": "fraunhofer-aisec",
 	"categories": [],
 	"engines": {
-		"vscode": "1.60.0"
+		"vscode": "^1.60.0"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^7.0.0"
@@ -55,7 +55,7 @@
 	"devDependencies": {
 		"@types/mocha": "9.0.0",
 		"@types/node": "16.11.7",
-		"@types/vscode": "1.60.0",
+		"@types/vscode": "^1.60.0",
 		"@typescript-eslint/parser": "5.3.1",
 		"eslint": "8.2.0",
 		"mocha": "9.1.3",


### PR DESCRIPTION
Set engine and @types/vscode back to version range. Both are set to the same range value.

This should improve usability of Codyze VSCode plugin as exact version matches are removed. The exact version causes problems when VSCode releases outpace the version demanded by the plugin. This has prevented the installation of the plugin in newer VSCode instances.