### PR TITLE
Preserve version range for VSCode by bumping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
     {
       "groupName": "picocli packages",
       "packagePatterns": ["^info.picocli:"]
+    },
+    {
+      "matchPackagePatterns": ["@types/vscode"],
+      "rangeStrategy": "bump"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
   "packageRules": [
     {
       "groupName": "picocli packages",
-      "packagePatterns": ["^info.picocli:"]
+      "matchPackagePatterns": ["^info.picocli:"]
     },
     {
       "matchPackagePatterns": ["@types/vscode"],


### PR DESCRIPTION
We want to maintain the version range for our VSCode plugin. At the same time we want to move along with newer versions. Therefore, we will bump the version.

This should allow slightly outdated plugin versions to still work in newer versions of VSCode. This has been a problem with pinned dependency updates. It prevented the installation of our plugin after VSCode updates as long as our own update lagged behind.

At the same time, I've updated the format to match the latest renovate configuration specification.

Relates to #348 and #349 