### PR TITLE
Use short message for unit tests

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/Finding.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/Finding.java
@@ -52,12 +52,12 @@ public class Finding {
 	/**
 	 * Constructor.
 	 *
-	 * @param logMsg           Log message for that specific finding. This message is created by the analysis module and may contain further descriptions and details of the
-	 *                         finding.
-	 * @param startLine        Line in code where the finding begins. Note that LSP starts counting at 1.
-	 * @param endLine          Line in code where the finding ends.
-	 * @param startColumn      Column in code where the finding begins. Note that LPS start counting at 1.
-	 * @param endColumn        Column in code where the finding ends.
+	 * @param logMsg      Log message for that specific finding. This message is created by the analysis module and may contain further descriptions and details of the
+	 *                    finding.
+	 * @param startLine   Line in code where the finding begins. Note that LSP starts counting at 1.
+	 * @param endLine     Line in code where the finding ends.
+	 * @param startColumn Column in code where the finding begins. Note that LPS start counting at 1.
+	 * @param endColumn   Column in code where the finding ends.
 	 */
 	public Finding(String id, Action action, String logMsg, @Nullable URI artifactUri, int startLine, int endLine, int startColumn,
 			int endColumn) {
@@ -74,11 +74,11 @@ public class Finding {
 	 * Constructor.
 	 *
 	 * @param id
-	 * @param logMsg           Log message for that specific finding. This message is created by the analysis module and may contain further descriptions and details of the
-	 *                         finding.
-	 * @param artifactUri      Absolute URI of the source file.
-	 * @param ranges           List of LSP "ranges" determining the position(s) in code of this finding. Note that a LSP range starts counting at 1, while a CPG "region" starts
-	 * @param isProblem        true, if this Finding represents a vulnerability/weakness. False, if the Finding confirms that the code is actually correct.
+	 * @param logMsg      Log message for that specific finding. This message is created by the analysis module and may contain further descriptions and details of the
+	 *                    finding.
+	 * @param artifactUri Absolute URI of the source file.
+	 * @param ranges      List of LSP "ranges" determining the position(s) in code of this finding. Note that a LSP range starts counting at 1, while a CPG "region" starts
+	 * @param isProblem   true, if this Finding represents a vulnerability/weakness. False, if the Finding confirms that the code is actually correct.
 	 */
 	public Finding(String id, Action action, String logMsg, @Nullable URI artifactUri, List<Region> ranges, boolean isProblem) {
 		this.id = id;
@@ -136,9 +136,9 @@ public class Finding {
 		String addIfExists = "";
 
 		// simple for now
-		String descriptionShort = FindingDescription.getInstance().getDescriptionShort(id);
-		if (descriptionShort != null && !descriptionShort.equals(id)) {
-			addIfExists = ": " + descriptionShort;
+		String description = isProblem() ? FindingDescription.getInstance().getDescriptionShort(id) : FindingDescription.getInstance().getDescriptionPass(id);
+		if (description != null && !description.equals(id)) {
+			addIfExists = ": " + description;
 		}
 
 		return toShortMessage() + addIfExists;

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/Finding.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/Finding.java
@@ -141,13 +141,7 @@ public class Finding {
 			addIfExists = ": " + descriptionShort;
 		}
 
-		String lines;
-		if (locations.size() == 1) {
-			lines = (locations.get(0).getRegion().getStartLine() + 1) + "";
-		} else {
-			lines = "[" + locations.stream().map(loc -> "" + (loc.getRegion().getStartLine() + 1)).sorted().distinct().collect(Collectors.joining(", ")) + "]";
-		}
-		return "line " + lines + ": " + logMsg + addIfExists;
+		return toShortMessage() + addIfExists;
 	}
 
 	public boolean equals(Object obj) {
@@ -181,6 +175,16 @@ public class Finding {
 		}
 
 		out.println(lines + ": " + (isProblem ? "(BAD)  " : "(GOOD) ") + shortMsg + ": " + logMsg);
+	}
+
+	public String toShortMessage() {
+		String lines;
+		if (locations.size() == 1) {
+			lines = (locations.get(0).getRegion().getStartLine() + 1) + "";
+		} else {
+			lines = "[" + locations.stream().map(loc -> "" + (loc.getRegion().getStartLine() + 1)).sorted().distinct().collect(Collectors.joining(", ")) + "]";
+		}
+		return "line " + lines + ": " + logMsg;
 	}
 
 }

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AbstractMarkTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AbstractMarkTest.kt
@@ -115,29 +115,29 @@ abstract class AbstractMarkTest : AbstractTest() {
     protected fun expected(findings: MutableSet<Finding>, vararg expectedFindings: String) {
         println("All findings:")
         for (f in findings) {
-            println(f.toString())
+            println(f.toShortMessage())
         }
 
         for (expected in expectedFindings) {
             assertEquals(
                 1,
-                findings.stream().filter { f: Finding -> f.toString() == expected }.count(),
+                findings.stream().filter { f: Finding -> f.toShortMessage() == expected }.count(),
                 "not found: \"$expected\""
             )
             val first =
-                findings.stream().filter { f: Finding -> f.toString() == expected }.findFirst()
+                findings.stream().filter { f: Finding -> f.toShortMessage() == expected }.findFirst()
             findings.remove(first.get())
         }
         if (findings.size > 0) {
             println("Additional Findings:")
             for (f in findings) {
-                println(f.toString())
+                println(f.toShortMessage())
             }
         }
         assertEquals(
             0,
             findings.size,
-            findings.stream().map { obj: Finding -> obj.toString() }.collect(Collectors.joining())
+            findings.stream().map { obj: Finding -> obj.toShortMessage() }.collect(Collectors.joining())
         )
     }
 
@@ -148,13 +148,13 @@ abstract class AbstractMarkTest : AbstractTest() {
      */
     protected fun containsFindings(findings: Set<Finding>, vararg expectedFindings: String) {
         println("All findings:")
-        for (f in findings) println(f.toString())
+        for (f in findings) println(f.toShortMessage())
 
         val missingFindings = mutableSetOf<String>()
         for (expected in expectedFindings) {
             var found = false
             for (finding in findings) {
-                if (expected == finding.toString()) {
+                if (expected == finding.toShortMessage()) {
                     found = true
                     break
                 }

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AbstractMarkTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AbstractMarkTest.kt
@@ -125,7 +125,10 @@ abstract class AbstractMarkTest : AbstractTest() {
                 "not found: \"$expected\""
             )
             val first =
-                findings.stream().filter { f: Finding -> f.toShortMessage() == expected }.findFirst()
+                findings
+                    .stream()
+                    .filter { f: Finding -> f.toShortMessage() == expected }
+                    .findFirst()
             findings.remove(first.get())
         }
         if (findings.size > 0) {
@@ -137,7 +140,10 @@ abstract class AbstractMarkTest : AbstractTest() {
         assertEquals(
             0,
             findings.size,
-            findings.stream().map { obj: Finding -> obj.toShortMessage() }.collect(Collectors.joining())
+            findings
+                .stream()
+                .map { obj: Finding -> obj.toShortMessage() }
+                .collect(Collectors.joining())
         )
     }
 


### PR DESCRIPTION
Unit tests use the `toString()` of `Finding`. It includes the descriptions from `findingDescriptions.json`. However, changing the description breaks unit tests as they compare the produced message string.

This addition introduces a short description that is not dependent on descriptions of findings. Consequently, unit tests are adjusted.

Moreover, the message generated for findings now uses the `passMessage` from `findingDescriptions.json` if the finding has been verified.