### PR TITLE
Change rule evaluation to create finding on errors

### DIFF
--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/BotanRulesTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/BotanRulesTest.kt
@@ -16,7 +16,9 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 21: Violation against Order: rng.random_vec(enc->default_nonce_length()) (get_random) is not allowed. Expected one of: r.create (RNGOrder)", // default ctor-problem in CPG
             "line 21: Violation against Order: enc->start(rng.random_vec(enc->default_nonce_length())); (start_iv) is not allowed. Expected one of: cm.set_key (Cipher_Mode_Order)", // ok
             "line 15: Violation against Order: Base enc is not correctly terminated. Expected one of [cm.set_key] to follow the correct last call on this base. (Cipher_Mode_Order)", // ok
-            "line 15: Rule _2_01_KeyLength violated" // ok
+            "line 15: Rule _2_01_KeyLength violated", // ok
+            "line [10, 15]: Rule _2_1_2_3_01_CBC_RandomIV violated",
+            "line 15: Rule UseOfPipe violated"
         )
     }
 
@@ -31,7 +33,9 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 21: Violation against Order: rng.random_vec(enc->default_nonce_length()) (get_random) is not allowed. Expected one of: r.create (RNGOrder)", // default ctor-problem in CPG
             "line 21: Violation against Order: enc->start(rng.random_vec(enc->default_nonce_length())); (start_iv) is not allowed. Expected one of: cm.set_key (Cipher_Mode_Order)", // ok
             "line 15: Violation against Order: Base enc is not correctly terminated. Expected one of [cm.set_key] to follow the correct last call on this base. (Cipher_Mode_Order)", // ok
-            "line 15: Rule _2_01_KeyLength violated" // ok
+            "line 15: Rule _2_01_KeyLength violated", // ok
+            "line [10, 15]: Rule _2_1_2_3_01_CBC_RandomIV violated",
+            "line 15: Rule UseOfPipe violated"
         )
     }
 
@@ -47,7 +51,8 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 15: Violation against Order: Base enc is not correctly terminated. Expected one of [cm.set_key] to follow the correct last call on this base. (Cipher_Mode_Order)", // ok
             "line 15: Rule _2_1_01_Modes violated", // ok
             "line 15: Rule _2_01_KeyLength violated", // ok
-            "line 15: Rule _2_1_2_1_02_CCM_TagSize verified" // ok
+            "line 15: Rule _2_1_2_1_02_CCM_TagSize verified", // ok
+            "line 15: Rule UseOfPipe violated"
         )
     }
 
@@ -63,7 +68,8 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 15: Violation against Order: Base enc is not correctly terminated. Expected one of [cm.set_key] to follow the correct last call on this base. (Cipher_Mode_Order)", // ok
             "line 15: Rule _2_1_01_Modes violated", // ok
             "line 15: Rule _2_01_KeyLength violated", // ok
-            "line 15: Rule _2_1_2_2_03_GCM_TagSize verified" // ok
+            "line 15: Rule _2_1_2_2_03_GCM_TagSize verified", // ok
+            "line 15: Rule UseOfPipe violated"
         )
     }
 
@@ -81,7 +87,9 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 21: Violation against Order: rng.random_vec(enc->default_nonce_length()) (get_random) is not allowed. Expected one of: r.create (RNGOrder)", // default ctor-problem in CPG
             "line 21: Violation against Order: enc->start(rng.random_vec(enc->default_nonce_length())); (start_iv) is not allowed. Expected one of: cm.set_key (Cipher_Mode_Order)", // ok
             "line 15: Violation against Order: Base enc is not correctly terminated. Expected one of [cm.set_key] to follow the correct last call on this base. (Cipher_Mode_Order)", // ok
-            "line 15: Rule _2_01_KeyLength violated" // ok
+            "line 15: Rule _2_01_KeyLength violated", // ok
+            "line [10, 15]: Rule _2_1_2_3_01_CBC_RandomIV violated",
+            "line 15: Rule UseOfPipe violated"
         )
     }
 
@@ -93,8 +101,8 @@ internal class BotanRulesTest : AbstractMarkTest() {
             findings,
             "line 21: Rule _3_3_03_ECIES_KDF verified", // ok
             "line 17: Rule _3_3_02_CurveParams verified", // ok
-            "line 19: Verified Order: PrivKeyOrder"
-        ) // ok
+            "line 19: Verified Order: PrivKeyOrder" // ok
+        )
     }
 
     @Test
@@ -123,7 +131,9 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 19: Rule _3_4_02_DLIES_KEYLEN verified", // ok
             "line 30: Rule _5_3_01_MAC verified", // ok
             "line 19: Rule _7_2_2_1_01_DH_KEYLEN_2022 verified", // ok
-            "line 19: Rule _7_2_2_1_01_DH_KEYLEN verified" // ok
+            "line 19: Rule _7_2_2_1_01_DH_KEYLEN verified", // ok
+            "line 30: Rule _5_3_02_MAC_KEYLEN violated",
+            "line 30: Rule _5_3_03_MAC_NONCELEN violated"
         )
     }
 
@@ -140,7 +150,9 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 27: Violation against Order: Base mac is not correctly terminated. Expected one of [m.init] to follow the correct last call on this base. (MACOrder)", // ok
             "line 24: Rule _3_4_01_DLIES_KDF verified", // ok
             "line 17: Rule _7_2_2_1_01_DH_KEYLEN_2022 verified", // ok
-            "line 17: Rule _7_2_2_1_01_DH_KEYLEN verified" // ok
+            "line 17: Rule _7_2_2_1_01_DH_KEYLEN verified", // ok
+            "line 27: Rule _5_3_03_MAC_NONCELEN violated",
+            "line 27: Rule _5_3_02_MAC_KEYLEN violated"
         )
     }
 
@@ -167,7 +179,9 @@ internal class BotanRulesTest : AbstractMarkTest() {
             findings,
             "line 12: Violation against Order: Base mac is not correctly terminated. Expected one of [m.init] to follow the correct last call on this base. (MACOrder)", // ok
             "line 22: Violation against Order: mac->start(iv); (start) is not allowed. Expected one of: END (MACOrder)", // ok
-            "line 12: Rule _5_3_01_MAC verified" // ok
+            "line 12: Rule _5_3_01_MAC verified", // ok
+            "line 12: Rule _5_3_03_MAC_NONCELEN violated",
+            "line 12: Rule _5_3_02_MAC_KEYLEN violated"
         )
     }
 
@@ -180,7 +194,8 @@ internal class BotanRulesTest : AbstractMarkTest() {
             "line 11: Rule _5_3_02_MAC_KEYLEN verified", // ok
             "line 14: Rule _5_3_01_MAC verified", // ok
             "line 14: Violation against Order: Base mac is not correctly terminated. Expected one of [m.init] to follow the correct last call on this base. (MACOrder)", // ok
-            "line 24: Violation against Order: mac->start(iv); (start) is not allowed. Expected one of: END (MACOrder)" // ok
+            "line 24: Violation against Order: mac->start(iv); (start) is not allowed. Expected one of: END (MACOrder)", // ok
+            "line 14: Rule _5_3_03_MAC_NONCELEN violated"
         )
     }
 

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkCppTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkCppTest.kt
@@ -28,7 +28,7 @@ internal class MarkCppTest : AbstractMarkTest() {
     @Throws(Exception::class)
     fun testNewExpression() {
         val findings = performTest("mark_cpp/new.cpp", "mark_cpp/new.mark")
-        expected(findings, "line 10: Rule MustBeOne violated")
+        expected(findings, "line 9: Rule MustBeOne violated", "line 10: Rule MustBeOne violated")
     }
 
     @Test

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkCppTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkCppTest.kt
@@ -28,7 +28,7 @@ internal class MarkCppTest : AbstractMarkTest() {
     @Throws(Exception::class)
     fun testNewExpression() {
         val findings = performTest("mark_cpp/new.cpp", "mark_cpp/new.mark")
-        expected(findings, "line 9: Rule MustBeOne violated", "line 10: Rule MustBeOne violated")
+        containsFindings(findings, "line 10: Rule MustBeOne violated")
     }
 
     @Test

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkJavaTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkJavaTest.kt
@@ -80,6 +80,7 @@ internal class MarkJavaTest : AbstractMarkTest() {
         // todo: missing: Enum is not handled yet
         expected(
             findings,
+            "line 11: Rule Enum violated",
             "line [17, 3]: Rule Static verified",
             "line [15, 3]: Rule Static verified"
         )

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/WpdsTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/WpdsTest.kt
@@ -79,7 +79,7 @@ internal class WpdsTest : AbstractMarkTest() {
 
         // Note that line numbers of the "range" are the actual line numbers -1. This is required
         // for proper LSP->editor mapping
-        assertEquals(7, findings.stream().filter { obj: Finding? -> obj!!.isProblem }.count())
+        assertEquals(9, findings.stream().filter { obj: Finding? -> obj!!.isProblem }.count())
     }
 
     @Test


### PR DESCRIPTION
When an evaluation of a rule returns an error, a finding is generated. The
finding is a rule violation. This change is more appropriate to reflect
the result of a rule evaluation. On an error, some part of a rule couldn't
be analyzed. Thus, it's unknown if a true violation exists. However,
ignoring the error may suggest that a rule is valid. This may be the more
severe conclusion. In addition, rules with errors need to be checked
manually to ensure compliance.

This change adjust unit test that changed due to the change in rule
evaluation.