### PR TITLE
Fixed getRegionByNode returning endLine instead of endColumn

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/utils/Utils.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/utils/Utils.java
@@ -284,7 +284,7 @@ public class Utils {
 		int startLine = n.getLocation().getRegion().getStartLine() - 1;
 		int endLine = n.getLocation().getRegion().getEndLine() - 1;
 		int startColumn = n.getLocation().getRegion().getStartColumn() - 1;
-		int endColumn = n.getLocation().getRegion().getEndLine() - 1;
+		int endColumn = n.getLocation().getRegion().getEndColumn() - 1;
 		return new Region(startLine, startColumn, endLine, endColumn);
 	}
 


### PR DESCRIPTION
bug produced findings with incorrect endColumns.