### PR TITLE
Fix VSCode version and maintain revovate

### DIFF
--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -11,7 +11,7 @@
 	"publisher": "fraunhofer-aisec",
 	"categories": [],
 	"engines": {
-		"vscode": "^1.999.0"
+		"vscode": "^1.62.0"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^7.0.0"

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,13 @@
 {
   "extends": [
     "config:base",
+    ":disableDependencyDashboard",
     ":assignAndReview(fwendland)",
     ":enableVulnerabilityAlerts",
     ":separateMultipleMajorReleases"
   ],
   "ignoreDeps": [
-    "de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark",
-    "org.apache.tinkerpop:gremlin-core",
-    "org.apache.tinkerpop:gremlin-driver",
-    "org.apache.tinkerpop:gremlin-python",
-    "org.apache.tinkerpop:neo4j-gremlin",
-    "org.apache.tinkerpop:tinkergraph-gremlin",
-    "com.steelbridgelabs.oss:neo4j-gremlin-bolt"
+    "de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark"
   ],
   "ignorePaths": ["scripts", "docs"],
   "packageRules": [
@@ -21,13 +16,14 @@
       "matchPackagePatterns": ["^info.picocli:"]
     },
     {
-      "groupName": "Codyze VSCode plugin",
+      "groupName": "VSCode plugin dependencies",
       "matchPaths": ["plugins/vscode/**"],
       "extends": ["schedule:earlyMondays"]
     },
     {
       "matchPackageNames": ["vscode"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "allowdVersions": "<1.999.0"
     }
   ]
 }


### PR DESCRIPTION
- VSCode has introduced a testing tag 1.999.0 (cf. [microsoft/vscode #75639](https://github.com/microsoft/vscode/issues/75639)). This tag is being picked up by renovate and considered a valid VSCode version. This not the case. We now restrict VSCode version to below 1.999.0.
- Clean up obsolete and removed `ignoreDeps` from renovate.
- Change versions back in `package.json`.
- Disabled renovate's dependency dashboard. We're probably not going to use it.