### PR TITLE
Prepare release 2.0.0-beta1

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * Start point of the standalone analysis server.
  */
 @SuppressWarnings("java:S106")
-@Command(name = "codyze", mixinStandardHelpOptions = true, version = "1.5.0", description = "Codyze finds security flaws in source code", sortOptions = false, usageHelpWidth = 100)
+@Command(name = "codyze", mixinStandardHelpOptions = true, version = "2.0.0-beta1", description = "Codyze finds security flaws in source code", sortOptions = false, usageHelpWidth = 100)
 public class Main implements Callable<Integer> {
 	private static final Logger log = LoggerFactory.getLogger(Main.class);
 


### PR DESCRIPTION
*  Bump version shown on CLI
*  Bump MARK version to latest release on GitHub

Blocked by:
- [x] https://github.com/Fraunhofer-AISEC/cpg/pull/623 - comes in with new CPG release 4.1.2
- [x] https://github.com/Fraunhofer-AISEC/codyze/pull/372
- [x] https://github.com/Fraunhofer-AISEC/codyze/pull/373