### PR TITLE
Support unity builds in CLI mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Code Property Graph
-    api("de.fraunhofer.aisec:cpg:4.1.1") // ok
+    //api("de.fraunhofer.aisec:cpg:4.1.1") // ok
+    api("com.github.Fraunhofer-AISEC:cpg:3ca9ce5c6")
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,15 +86,11 @@ dependencies {
     api("org.apache.logging.log4j:log4j-core:2.14.1") // impl in main; used only in test
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:2.14.1")
 
-    // will be a transitive dependency after CPG beta.3
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
-
     // pull in explicitly to prevent mixing versions
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Code Property Graph
-    //api("de.fraunhofer.aisec:cpg:4.1.1") // ok
-    api("com.github.Fraunhofer-AISEC:cpg:3ca9ce5c6")
+    api("de.fraunhofer.aisec:cpg:4.1.2")
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -42,8 +42,8 @@ public class Main implements Callable<Integer> {
 	@Option(names = { "-s", "--source" }, paramLabel = "<path>", description = "Source file or folder to analyze.")
 	private File analysisInput;
 
-	@Option(names = { "--unity" }, description = "Enables unity builds (C++ only) for files in the path. Enabled by default in CLI mode.")
-	private Boolean useUnityBuild;
+	@Option(names = { "--unity" }, description = "Enables unity builds (C++ only) for files in the path")
+	private boolean useUnityBuild = false;
 
 	@Option(names = { "-m",
 			"--mark" }, paramLabel = "<path>", description = "Loads MARK policy files", defaultValue = "./", showDefaultValue = CommandLine.Help.Visibility.ON_DEMAND, split = ",")
@@ -80,12 +80,6 @@ public class Main implements Callable<Integer> {
 
 		if (analysisMode.tsMode == null) {
 			analysisMode.tsMode = TypestateMode.NFA;
-		}
-
-		// check, if unity build was not explicitly set
-		if (useUnityBuild == null) {
-			// set it to true, if we are in CLI mode
-			useUnityBuild = executionMode.cli;
 		}
 
 		// we need to force load includes for unity builds, otherwise nothing will be parsed

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -42,6 +42,9 @@ public class Main implements Callable<Integer> {
 	@Option(names = { "-s", "--source" }, paramLabel = "<path>", description = "Source file or folder to analyze.")
 	private File analysisInput;
 
+	@Option(names = { "--unity" }, description = "Enables unity builds (C++ only) for files in the path. Enabled by default.")
+	private boolean unityBuild = true;
+
 	@Option(names = { "-m",
 			"--mark" }, paramLabel = "<path>", description = "Loads MARK policy files", defaultValue = "./", showDefaultValue = CommandLine.Help.Visibility.ON_DEMAND, split = ",")
 	private File[] markFolderNames;
@@ -86,6 +89,7 @@ public class Main implements Callable<Integer> {
 				.disableGoodFindings(disableGoodFindings)
 				.analyzeIncludes(translationSettings.analyzeIncludes)
 				.includePath(translationSettings.includesPath)
+				.unityBuild(unityBuild)
 				.markFiles(Arrays.stream(markFolderNames).map(File::getAbsolutePath).toArray(String[]::new));
 
 		if (enablePython) {

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
@@ -361,23 +361,14 @@ public class AnalysisServer {
 
 	public CompletableFuture<AnalysisContext> analyze(String url) {
 		List<File> files = new ArrayList<>();
-		File f = new File(url);
-		if (f.isDirectory()) {
-			File[] list = f.listFiles();
-			if (list != null) {
-				files.addAll(Arrays.asList(list));
-			} else {
-				log.error("Null file list");
-			}
-		} else {
-			files.add(f);
-		}
+		files.add(new File(url));
 
 		var translationConfig = TranslationConfiguration.builder()
 				.debugParser(true)
 				.failOnError(false)
 				.codeInNodes(true)
 				.loadIncludes(this.config.analyzeIncludes)
+				.useUnityBuild(this.config.useUnityBuild)
 				.defaultPasses()
 				.defaultLanguages()
 				.registerPass(new IdentifierPass())

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -27,10 +27,15 @@ public class ServerConfiguration {
 	public final TypestateMode typestateAnalysis;
 
 	/**
-	 * Passed down to {@link de.fraunhofer.aisec.cpg.TranslationConfiguration}. Whether or not to
+	 * Passed down to {@link de.fraunhofer.aisec.cpg.TranslationConfiguration}. Whether to
 	 * parse include files.
 	 */
 	public final boolean analyzeIncludes;
+
+	/**
+	 * Enables or disables unity builds (for C++ only).
+	 */
+	public final boolean useUnityBuild;
 
 	/**
 	 * Path(s) containing include files.
@@ -52,7 +57,7 @@ public class ServerConfiguration {
 			@NonNull String[] markModelFiles,
 			@NonNull TypestateMode typestateMode,
 			boolean analyzeIncludes,
-			boolean unityBuild,
+			boolean useUnityBuild,
 			@NonNull File[] includePath,
 			boolean disableGoodFindings,
 			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages) {
@@ -61,6 +66,7 @@ public class ServerConfiguration {
 		this.markModelFiles = markModelFiles;
 		this.typestateAnalysis = typestateMode;
 		this.analyzeIncludes = analyzeIncludes;
+		this.useUnityBuild = useUnityBuild;
 		this.includePath = includePath;
 		this.disableGoodFindings = disableGoodFindings;
 		this.additionalLanguages = additionalLanguages;
@@ -78,7 +84,7 @@ public class ServerConfiguration {
 		@NonNull
 		private TypestateMode typestateAnalysis = TypestateMode.NFA;
 		private boolean analyzeIncludes;
-		private boolean unityBuild = true;
+		private boolean useUnityBuild;
 		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
@@ -108,8 +114,8 @@ public class ServerConfiguration {
 			return this;
 		}
 
-		public Builder unityBuild(boolean unityBuild) {
-			this.unityBuild = unityBuild;
+		public Builder useUnityBuild(boolean useUnityBuild) {
+			this.useUnityBuild = useUnityBuild;
 			return this;
 		}
 
@@ -144,7 +150,7 @@ public class ServerConfiguration {
 				markModelFiles,
 				typestateAnalysis,
 				analyzeIncludes,
-				unityBuild,
+				useUnityBuild,
 				includePath,
 				disableGoodFindings,
 				additionalLanguages);

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -52,6 +52,7 @@ public class ServerConfiguration {
 			@NonNull String[] markModelFiles,
 			@NonNull TypestateMode typestateMode,
 			boolean analyzeIncludes,
+			boolean unityBuild,
 			@NonNull File[] includePath,
 			boolean disableGoodFindings,
 			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages) {
@@ -77,6 +78,7 @@ public class ServerConfiguration {
 		@NonNull
 		private TypestateMode typestateAnalysis = TypestateMode.NFA;
 		private boolean analyzeIncludes;
+		private boolean unityBuild = true;
 		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
@@ -103,6 +105,11 @@ public class ServerConfiguration {
 
 		public Builder analyzeIncludes(boolean analyzeIncludes) {
 			this.analyzeIncludes = analyzeIncludes;
+			return this;
+		}
+
+		public Builder unityBuild(boolean unityBuild) {
+			this.unityBuild = unityBuild;
 			return this;
 		}
 
@@ -137,6 +144,7 @@ public class ServerConfiguration {
 				markModelFiles,
 				typestateAnalysis,
 				analyzeIncludes,
+				unityBuild,
 				includePath,
 				disableGoodFindings,
 				additionalLanguages);

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,22 +1,14 @@
-<Configuration status="ERROR">
+<Configuration status="WARN">
     <Appenders>
-        <File name="FILEOUT" fileName="crymlin.log">
+        <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1} %m%n"/>
-        </File>
-        <Async name="Async">
-            <AppenderRef ref="FILEOUT"/>
-        </Async>
-
-        <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout   pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n" />
+            <ThresholdFilter level="DEBUG"/>
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="WARN" additivity="false">
-            <appender-ref ref="FILEOUT" />
+        <Logger level="INFO" name="de.fraunhofer.aisec"/>
+        <Root level="INFO">
+            <AppenderRef ref="STDOUT"/>
         </Root>
-        <logger level="WARN" additivity="false" name="de.fraunhofer.aisec">
-            <appender-ref ref="FILEOUT" />
-        </logger>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,14 +1,22 @@
-<Configuration status="WARN">
+<Configuration status="ERROR">
     <Appenders>
-        <Console name="STDOUT" target="SYSTEM_OUT">
+        <File name="FILEOUT" fileName="crymlin.log">
             <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1} %m%n"/>
-            <ThresholdFilter level="DEBUG"/>
+        </File>
+        <Async name="Async">
+            <AppenderRef ref="FILEOUT"/>
+        </Async>
+
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <PatternLayout   pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n" />
         </Console>
     </Appenders>
     <Loggers>
-        <Logger level="INFO" name="de.fraunhofer.aisec"/>
-        <Root level="INFO">
-            <AppenderRef ref="STDOUT"/>
+        <Root level="WARN" additivity="false">
+            <appender-ref ref="FILEOUT" />
         </Root>
+        <logger level="WARN" additivity="false" name="de.fraunhofer.aisec">
+            <appender-ref ref="FILEOUT" />
+        </logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
This PR adds a new configuration option for CPG unity builds. They are extremely helpful when analysing large chunks of C++ files in one go. They work ideally if the headers are using an [include guard](https://en.wikipedia.org/wiki/Include_guard) such as: 

```C
#ifndef MYHEADER_H
#define MYHEADER_H 

/* stuff */
#endif

In this case, the header will be included exactly once and no duplicate nodes exist in the code.