### PR TITLE
Implementing a version provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,8 @@ gradle.startParameter.excludedTaskNames += "licenseTest"
 tasks {
     jar {
         manifest {
-            attributes(Pair("CodyzeVersion", project.version))
+            attributes(Pair("Implementation-Title", "codyze"))
+            attributes(Pair("Implementation-Version", project.version))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.gradle.api.java.archives.Manifest
 import org.gradle.kotlin.dsl.attributes
 
-project.version = "2.0.0-alpha4"
-
 plugins {
     // built-in
     java
@@ -30,8 +28,10 @@ gradle.startParameter.excludedTaskNames += "licenseTest"
 tasks {
     jar {
         manifest {
-            attributes(Pair("Implementation-Title", "codyze"))
-            attributes(Pair("Implementation-Version", project.version))
+            attributes("Implementation-Title" to "codyze",
+                    "Implementation-Version" to archiveVersion.getOrElse("0.0.0-dev"),
+                    "Main-Class" to "de.fraunhofer.aisec.codyze.Main",
+                    "Class-Path" to configurations.compileClasspath.get().asPath)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.api.java.archives.Manifest
 import org.gradle.kotlin.dsl.attributes
 
 plugins {
@@ -29,9 +28,7 @@ tasks {
     jar {
         manifest {
             attributes("Implementation-Title" to "codyze",
-                    "Implementation-Version" to archiveVersion.getOrElse("0.0.0-dev"),
-                    "Main-Class" to "de.fraunhofer.aisec.codyze.Main",
-                    "Class-Path" to configurations.compileClasspath.get().asPath)
+                    "Implementation-Version" to archiveVersion.getOrElse("0.0.0-dev"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.api.java.archives.Manifest
+import org.gradle.kotlin.dsl.attributes
+
+project.version = "2.0.0-alpha4"
 
 plugins {
     // built-in
@@ -22,6 +26,14 @@ group = "de.fraunhofer.aisec"
  */
 gradle.startParameter.excludedTaskNames += "licenseMain"
 gradle.startParameter.excludedTaskNames += "licenseTest"
+
+tasks {
+    jar {
+        manifest {
+            attributes(Pair("CodyzeVersion", project.version))
+        }
+    }
+}
 
 tasks.jacocoTestReport {
     reports {

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -197,8 +197,7 @@ class ManifestVersionProvider implements CommandLine.IVersionProvider {
 				Manifest manifest = new Manifest(url.openStream());
 				if (isApplicableManifest(manifest)) {
 					Attributes attr = manifest.getMainAttributes();
-					return new String[] { get(attr, "Implementation-Title") + " version \"" +
-							get(attr, "Implementation-Version") + "\"" };
+					return new String[] { get(attr, "Implementation-Version").toString() };
 				}
 			}
 			catch (IOException ex) {
@@ -210,7 +209,7 @@ class ManifestVersionProvider implements CommandLine.IVersionProvider {
 
 	private boolean isApplicableManifest(Manifest manifest) {
 		Attributes attributes = manifest.getMainAttributes();
-		return "codyze".equals(get(attributes, "Implementation-Name"));
+		return "codyze".equals(get(attributes, "Implementation-Title"));
 	}
 
 	private static Object get(Attributes attributes, String key) {

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -44,6 +44,9 @@ public class Main implements Callable<Integer> {
 	@Option(names = { "-s", "--source" }, paramLabel = "<path>", description = "Source file or folder to analyze.")
 	private File analysisInput;
 
+	@Option(names = { "--unity" }, description = "Enables unity builds (C++ only) for files in the path")
+	private boolean useUnityBuild = false;
+
 	@Option(names = { "-m",
 			"--mark" }, paramLabel = "<path>", description = "Loads MARK policy files", defaultValue = "./", showDefaultValue = CommandLine.Help.Visibility.ON_DEMAND, split = ",")
 	private File[] markFolderNames;
@@ -81,6 +84,11 @@ public class Main implements Callable<Integer> {
 			analysisMode.tsMode = TypestateMode.NFA;
 		}
 
+		// we need to force load includes for unity builds, otherwise nothing will be parsed
+		if (useUnityBuild) {
+			translationSettings.analyzeIncludes = true;
+		}
+
 		var config = ServerConfiguration.builder()
 				.launchLsp(executionMode.lsp)
 				.launchConsole(executionMode.tui)
@@ -88,6 +96,7 @@ public class Main implements Callable<Integer> {
 				.disableGoodFindings(disableGoodFindings)
 				.analyzeIncludes(translationSettings.analyzeIncludes)
 				.includePath(translationSettings.includesPath)
+				.useUnityBuild(useUnityBuild)
 				.markFiles(Arrays.stream(markFolderNames).map(File::getAbsolutePath).toArray(String[]::new));
 
 		if (enablePython) {
@@ -178,7 +187,7 @@ class AnalysisMode {
 
 class TranslationSettings {
 	@Option(names = {
-			"--analyze-includes" }, description = "Enables parsing of include files. By default, if --includes are given, the parser will resolve symbols/templates from these include, but not load their parse tree.")
+			"--analyze-includes" }, description = "Enables parsing of include files. By default, if --includes are given, the parser will resolve symbols/templates from these include, but not load their parse tree. This will enforced to true, if unity builds are used.")
 	protected boolean analyzeIncludes = false;
 
 	@Option(names = { "--includes" }, description = "Path(s) containing include files. Path must be separated by : (Mac/Linux) or ; (Windows)", split = ":|;")

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -14,8 +14,6 @@ import picocli.CommandLine.Option;
 
 import java.io.*;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -202,11 +200,12 @@ class ManifestVersionProvider implements CommandLine.IVersionProvider {
 					return new String[] { get(attr, "Implementation-Title") + " version \"" +
 							get(attr, "Implementation-Version") + "\"" };
 				}
-			} catch (IOException ex) {
+			}
+			catch (IOException ex) {
 				return new String[] { "Unable to read from " + url + ": " + ex };
 			}
 		}
-		return new String[] { "Unable to find manifest file."};
+		return new String[] { "Unable to find manifest file." };
 	}
 
 	private boolean isApplicableManifest(Manifest manifest) {


### PR DESCRIPTION
Attempts to store the version number (or "0.0.0-dev" for local builds) in the manifest file.
The version can then be retrieved with the help of Main.ManifestVersionProvider.
This makes manual version updating obsolete (resolves #104) and enables easy synchronisation of the version number throughout the project.