### PR TITLE
Combine CPG packages into one group for simultaneous updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
   "ignorePaths": ["scripts", "docs"],
   "packageRules": [
     {
+      "matchPackagePrefixes": ["de.fraunhofer.aisec:cpg"],
+      "groupName": "CPG packages"
+    {
       "groupName": "picocli packages",
       "matchPackagePatterns": ["^info.picocli:"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
     {
       "matchPackagePrefixes": ["de.fraunhofer.aisec:cpg"],
       "groupName": "CPG packages"
+    },
     {
       "groupName": "picocli packages",
       "matchPackagePatterns": ["^info.picocli:"]


### PR DESCRIPTION
The CPG comes in multiple packages. To prevent renovate from creating a PR for each package, this configuration change groups them together.

This should prevent build errors where non-matching package versions are used.