### PR TITLE
Load additional CPG frontends dynamically based on class name

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -7,11 +7,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
-import de.fraunhofer.aisec.cpg.ExperimentalGolang
-import de.fraunhofer.aisec.cpg.ExperimentalPython
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
-import de.fraunhofer.aisec.cpg.frontends.golang.GoLanguageFrontend
-import de.fraunhofer.aisec.cpg.frontends.python.PythonLanguageFrontend
+import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend
 import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
 import de.fraunhofer.aisec.cpg.passes.IdentifierPass
 import java.io.File
@@ -47,8 +44,6 @@ class Configuration {
      *
      * @return ServerConfiguration
      */
-    @ExperimentalGolang
-    @ExperimentalPython
     fun buildServerConfiguration(): ServerConfiguration {
         val config =
             ServerConfiguration.builder()
@@ -62,16 +57,47 @@ class Configuration {
                 .includePath(cpg.translation.includes)
                 .useUnityBuild(cpg.useUnityBuild)
         if (cpg.additionalLanguages.contains(Language.PYTHON) || cpg.enablePython) {
-            config.registerLanguage(
-                PythonLanguageFrontend::class.java,
-                PythonLanguageFrontend.PY_EXTENSIONS
-            )
+            val pythonFrontendClazz =
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    Class.forName(Language.PYTHON.frontendClassName) as Class<LanguageFrontend>
+                } catch (e: Throwable) {
+                    log.warn("Unable to initialize Python frontend for CPG")
+                    null
+                }
+
+            if (pythonFrontendClazz != null) {
+                @Suppress("UNCHECKED_CAST")
+                val extensions =
+                    pythonFrontendClazz
+                        .fields
+                        .find { f -> f.name.endsWith("_EXTENSIONS") }
+                        ?.get(null) as
+                        List<String>
+
+                config.registerLanguage(pythonFrontendClazz, extensions)
+            }
         }
         if (cpg.additionalLanguages.contains(Language.GO) || cpg.enableGo) {
-            config.registerLanguage(
-                GoLanguageFrontend::class.java,
-                GoLanguageFrontend.GOLANG_EXTENSIONS
-            )
+            val golangFrontendClazz =
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    Class.forName(Language.GO.frontendClassName) as Class<LanguageFrontend>
+                } catch (e: Throwable) {
+                    log.warn("Unable to initialize Golang frontend for CPG")
+                    null
+                }
+            if (golangFrontendClazz != null) {
+                @Suppress("UNCHECKED_CAST")
+                val extensions =
+                    golangFrontendClazz
+                        .fields
+                        .find { f -> f.name.endsWith("_EXTENSIONS") }
+                        ?.get(null) as
+                        List<String>
+
+                config.registerLanguage(golangFrontendClazz, extensions)
+            }
         }
         return config.build()
     }
@@ -81,8 +107,6 @@ class Configuration {
      *
      * @return TranslationConfiguration
      */
-    @ExperimentalGolang
-    @ExperimentalPython
     fun buildTranslationConfiguration(): TranslationConfiguration {
         val files: MutableList<File> = ArrayList()
         files.add(File(codyze.source!!.absolutePath))
@@ -99,16 +123,47 @@ class Configuration {
                 .registerPass(EdgeCachePass())
                 .sourceLocations(*files.toTypedArray())
         if (cpg.additionalLanguages.contains(Language.PYTHON) || cpg.enablePython) {
-            translationConfig.registerLanguage(
-                PythonLanguageFrontend::class.java,
-                PythonLanguageFrontend.PY_EXTENSIONS
-            )
+            val pythonFrontendClazz =
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    Class.forName(Language.PYTHON.frontendClassName) as Class<LanguageFrontend>
+                } catch (e: Throwable) {
+                    log.warn("Unable to initialize Python frontend for CPG")
+                    null
+                }
+
+            if (pythonFrontendClazz != null) {
+                @Suppress("UNCHECKED_CAST")
+                val extensions =
+                    pythonFrontendClazz
+                        .fields
+                        .find { f -> f.name.endsWith("_EXTENSIONS") }
+                        ?.get(null) as
+                        List<String>
+
+                translationConfig.registerLanguage(pythonFrontendClazz, extensions)
+            }
         }
         if (cpg.additionalLanguages.contains(Language.GO) || cpg.enableGo) {
-            translationConfig.registerLanguage(
-                GoLanguageFrontend::class.java,
-                GoLanguageFrontend.GOLANG_EXTENSIONS
-            )
+            val golangFrontendClazz =
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    Class.forName(Language.GO.frontendClassName) as Class<LanguageFrontend>
+                } catch (e: Throwable) {
+                    log.warn("Unable to initialize Golang frontend for CPG")
+                    null
+                }
+            if (golangFrontendClazz != null) {
+                @Suppress("UNCHECKED_CAST")
+                val extensions =
+                    golangFrontendClazz
+                        .fields
+                        .find { f -> f.name.endsWith("_EXTENSIONS") }
+                        ?.get(null) as
+                        List<String>
+
+                translationConfig.registerLanguage(golangFrontendClazz, extensions)
+            }
         }
         for (file in cpg.translation.includes!!) translationConfig.includePath(file.absolutePath)
         return translationConfig.build()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Language.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Language.kt
@@ -1,6 +1,6 @@
 package de.fraunhofer.aisec.codyze.config
 
-enum class Language {
-    PYTHON,
-    GO
+enum class Language(val frontendClassName: String) {
+    PYTHON("de.fraunhofer.aisec.cpg.frontends.python.PythonLanguageFrontend"),
+    GO("de.fraunhofer.aisec.cpg.frontends.golang.GoLanguageFrontend")
 }

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLITest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLITest.kt
@@ -1,0 +1,27 @@
+package de.fraunhofer.aisec.codyze.crymlin
+
+import de.fraunhofer.aisec.codyze.config.Configuration
+import org.junit.jupiter.api.Test
+
+internal class CLITest {
+
+    @Test
+    fun enablePythonSupport() {
+        val cliParameters = arrayOf("-c", "--enable-python-support")
+        val config = Configuration.initConfig(null, *cliParameters)
+        config.buildServerConfiguration()
+
+        // able to handle missing frontends without crashing
+        assert(true)
+    }
+
+    @Test
+    fun useAdditionalLanguagePython() {
+        val cliParameters = arrayOf("-c", "--additional-languages=python")
+        val config = Configuration.initConfig(null, *cliParameters)
+        config.buildServerConfiguration()
+
+        // able to handle missing frontends without crashing
+        assert(true)
+    }
+}


### PR DESCRIPTION
Change code referencing frontend classes in CPG directly to dynamically retrieving classes based on fully-qualified class name. Prevents compile errors where frontends may not be available.

This fixes the compile error in #421.