### PR TITLE
Add flag `pedantic` to perform all analyses and post all findings 

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
@@ -110,6 +110,11 @@ public class AnalysisServer {
 		return instance;
 	}
 
+	@NonNull
+	public ServerConfiguration getServerConfiguration() {
+		return config;
+	}
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -213,7 +218,7 @@ public class AnalysisServer {
 				.thenApply(
 					ctx -> {
 						Benchmark bench = new Benchmark(AnalysisServer.class, "  Filtering results");
-						if (config.disableGoodFindings) {
+						if (!config.pedantic && config.disableGoodFindings) {
 							// Filter out "positive" results
 							ctx.getFindings().removeIf(finding -> !finding.isProblem());
 						}

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -48,6 +48,11 @@ public class ServerConfiguration {
 	/** If true, no "positive" findings will be returned from the analysis. */
 	public final boolean disableGoodFindings;
 
+	/**
+	 * Enables pedantic mode analyzing all MARK rules and reporting all findings regardless of other configuration options.
+	 */
+	public final boolean pedantic;
+
 	/** Additional registered languages */
 	public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages;
 
@@ -60,6 +65,7 @@ public class ServerConfiguration {
 			boolean useUnityBuild,
 			@NonNull File[] includePath,
 			boolean disableGoodFindings,
+			boolean pedantic,
 			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages) {
 		this.launchConsole = launchConsole;
 		this.launchLsp = launchLsp;
@@ -69,6 +75,7 @@ public class ServerConfiguration {
 		this.useUnityBuild = useUnityBuild;
 		this.includePath = includePath;
 		this.disableGoodFindings = disableGoodFindings;
+		this.pedantic = pedantic;
 		this.additionalLanguages = additionalLanguages;
 	}
 
@@ -87,6 +94,7 @@ public class ServerConfiguration {
 		private boolean useUnityBuild;
 		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
+		private boolean pedantic;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
 
 		public Builder launchConsole(boolean launchConsole) {
@@ -139,6 +147,11 @@ public class ServerConfiguration {
 			return this;
 		}
 
+		public Builder pedantic(boolean pedantic) {
+			this.pedantic = pedantic;
+			return this;
+		}
+
 		public Builder useLegacyEvaluator() {
 			return this;
 		}
@@ -153,6 +166,7 @@ public class ServerConfiguration {
 				useUnityBuild,
 				includePath,
 				disableGoodFindings,
+				pedantic,
 				additionalLanguages);
 		}
 	}

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -73,6 +73,14 @@ class CodyzeConfiguration {
         split = ","
     )
     var disabledMarkRules: List<String> = emptyList()
+
+    @Option(
+        names = ["--pedantic"],
+        description =
+            [
+                "Activates pedantic analysis mode. In this mode, Codyze analyzes all MARK rules and report all findings. This option overrides `disabledMarkRules` and `noGoodFinding` and ignores any Codyze source code comments."]
+    )
+    var pedantic = false
 }
 
 /**

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -50,7 +50,13 @@ class Configuration {
                 .launchLsp(codyze.executionMode.isLsp)
                 .launchConsole(codyze.executionMode.isTui)
                 .typestateAnalysis(codyze.analysis.tsMode)
-                .disableGoodFindings(codyze.noGoodFindings)
+                .disableGoodFindings(
+                    if (codyze.pedantic) {
+                        false
+                    } else {
+                        codyze.noGoodFindings
+                    }
+                )
                 .markFiles(*codyze.mark.map { m -> m.absolutePath }.toTypedArray())
                 // TODO: remove all cpg config and replace with TranslationConfiguration
                 .analyzeIncludes(cpg.translation.analyzeIncludes)

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/connectors/lsp/CpgDocumentService.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/connectors/lsp/CpgDocumentService.java
@@ -97,7 +97,7 @@ public class CpgDocumentService implements TextDocumentService {
 
 			// check if there are disabled findings
 			@NonNull
-			Map<Integer, String> ignoredLines = getIgnoredLines(file);
+			Map<Integer, String> ignoredLines = instance.getServerConfiguration().pedantic ? Map.of() : getIgnoredLines(file);
 
 			List<Diagnostic> allDiags = findingsToDiagnostics(ctx.getFindings(), ignoredLines);
 
@@ -133,6 +133,7 @@ public class CpgDocumentService implements TextDocumentService {
 	@NonNull
 	private Map<Integer, String> getIgnoredLines(@NonNull File file) {
 		Map<Integer, String> ignoredLines = new HashMap<>();
+
 		try {
 			List<String> allLines = Files.readAllLines(Paths.get(file.getAbsolutePath()));
 			for (int i = 0; i < allLines.size(); i++) {

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
@@ -45,6 +45,7 @@ internal class CLILoadTest {
         assertEquals(TypestateMode.DFA, codyze.analysis.tsMode)
         assertEquals(120L, codyze.timeout)
         assertFalse(codyze.noGoodFindings)
+        assertFalse(codyze.pedantic)
         assertFalse(codyze.sarifOutput)
 
         assertFalse(cpg.translation.analyzeIncludes)


### PR DESCRIPTION
With flag `pedantic` Codyze will ignore options that disable MARK rules or ignore good findings. Moreover, all markup comments in source code that supress findings are ignored as well.