### PR TITLE
Mark rule disabling

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
@@ -3,6 +3,7 @@ package de.fraunhofer.aisec.codyze.analysis;
 
 import de.fraunhofer.aisec.codyze.JythonInterpreter;
 import de.fraunhofer.aisec.codyze.analysis.markevaluation.Evaluator;
+import de.fraunhofer.aisec.codyze.config.DisabledMarkRulesValue;
 import de.fraunhofer.aisec.codyze.crymlin.builtin.Builtin;
 import de.fraunhofer.aisec.codyze.crymlin.builtin.BuiltinRegistry;
 import de.fraunhofer.aisec.codyze.crymlin.connectors.lsp.CpgLanguageServer;
@@ -227,7 +228,7 @@ public class AnalysisServer {
 		 * Load MARK model as given in configuration, if it has not been set manually before.
 		 */
 		File[] markModelLocations = Arrays.stream(config.markModelFiles).map(File::new).toArray(File[]::new);
-		loadMarkRules(markModelLocations);
+		loadMarkRules(config.packageToDisabledMarkRules, markModelLocations);
 	}
 
 	/**
@@ -260,6 +261,16 @@ public class AnalysisServer {
 	 * @param markFiles load all mark entities/rules from these files
 	 */
 	public void loadMarkRules(@NonNull File... markFiles) {
+		loadMarkRules(new HashMap<>(), markFiles);
+	}
+
+	/**
+	 * Loads all MARK rules from a file or a directory but skips files specified in packageToDisabledMarkRules map
+	 *
+	 * @param markFiles load all mark entities/rules from these files
+	 * @param packageToDisabledMarkRules skip specified files during loading
+	 */
+	public void loadMarkRules(Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules, @NonNull File... markFiles) {
 		File markDescriptionFile = null;
 
 		XtextParser parser = new XtextParser();
@@ -307,7 +318,7 @@ public class AnalysisServer {
 
 		start = Instant.now();
 		log.info("Transforming MARK Xtext to internal format");
-		this.markModel = new MarkModelLoader().load(markModels, config.disabledMarkRules);
+		this.markModel = new MarkModelLoader().load(markModels, packageToDisabledMarkRules);
 		log.info(
 			"Done Transforming MARK Xtext to internal format in {} ms",
 			Duration.between(start, Instant.now()).toMillis());

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
@@ -307,7 +307,7 @@ public class AnalysisServer {
 
 		start = Instant.now();
 		log.info("Transforming MARK Xtext to internal format");
-		this.markModel = new MarkModelLoader().load(markModels);
+		this.markModel = new MarkModelLoader().load(markModels, config.disabledMarkRules);
 		log.info(
 			"Done Transforming MARK Xtext to internal format in {} ms",
 			Duration.between(start, Instant.now()).toMillis());

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -1,6 +1,7 @@
 
 package de.fraunhofer.aisec.codyze.analysis;
 
+import de.fraunhofer.aisec.codyze.config.DisabledMarkRulesValue;
 import de.fraunhofer.aisec.cpg.frontends.LanguageFrontend;
 import kotlin.Pair;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -9,7 +10,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /** The configuration for the {@link AnalysisServer} holds all values used by the server. */
 public class ServerConfiguration {
@@ -53,8 +53,8 @@ public class ServerConfiguration {
 	/** Additional registered languages */
 	public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages;
 
-	/** Disabled Mark rules */
-	public final Map<String, Pair<Boolean, Set<String>>> disabledMarkRules;
+	/** Disabled Mark rules. key=package, value=(disableEntirePackage, markRulesToDisable) */
+	public final Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules;
 
 	private ServerConfiguration(
 			boolean launchConsole,
@@ -66,7 +66,7 @@ public class ServerConfiguration {
 			@NonNull File[] includePath,
 			boolean disableGoodFindings,
 			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages,
-			Map<String, Pair<Boolean, Set<String>>> disabledMarkRules) {
+			Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules) {
 		this.launchConsole = launchConsole;
 		this.launchLsp = launchLsp;
 		this.markModelFiles = markModelFiles;
@@ -76,7 +76,7 @@ public class ServerConfiguration {
 		this.includePath = includePath;
 		this.disableGoodFindings = disableGoodFindings;
 		this.additionalLanguages = additionalLanguages;
-		this.disabledMarkRules = disabledMarkRules;
+		this.packageToDisabledMarkRules = packageToDisabledMarkRules;
 	}
 
 	public static Builder builder() {
@@ -95,7 +95,7 @@ public class ServerConfiguration {
 		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
-		private Map<String, Pair<Boolean, Set<String>>> disabledMarkRules;
+		private Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules;
 
 		public Builder launchConsole(boolean launchConsole) {
 			this.launchConsole = launchConsole;
@@ -151,8 +151,8 @@ public class ServerConfiguration {
 			return this;
 		}
 
-		public Builder disableMark(Map<String, Pair<Boolean, Set<String>>> disabledMarkRules) {
-			this.disabledMarkRules = disabledMarkRules;
+		public Builder disableMark(Map<String, DisabledMarkRulesValue> disabledMarkRules) {
+			this.packageToDisabledMarkRules = disabledMarkRules;
 			return this;
 		}
 
@@ -167,7 +167,7 @@ public class ServerConfiguration {
 				includePath,
 				disableGoodFindings,
 				additionalLanguages,
-				disabledMarkRules);
+				packageToDisabledMarkRules);
 		}
 	}
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -103,7 +104,7 @@ public class ServerConfiguration {
 		private boolean disableGoodFindings;
 		private boolean pedantic;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
-		private Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules;
+		private Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules = Collections.emptyMap();
 
 		public Builder launchConsole(boolean launchConsole) {
 			this.launchConsole = launchConsole;

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -54,7 +54,7 @@ public class ServerConfiguration {
 	public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages;
 
 	/** Disabled Mark rules */
-	public final Map<String, Pair<Boolean, Set<String>>> disabledMark;
+	public final Map<String, Pair<Boolean, Set<String>>> disabledMarkRules;
 
 	private ServerConfiguration(
 			boolean launchConsole,
@@ -66,7 +66,7 @@ public class ServerConfiguration {
 			@NonNull File[] includePath,
 			boolean disableGoodFindings,
 			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages,
-			Map<String, Pair<Boolean, Set<String>>> disabledMark) {
+			Map<String, Pair<Boolean, Set<String>>> disabledMarkRules) {
 		this.launchConsole = launchConsole;
 		this.launchLsp = launchLsp;
 		this.markModelFiles = markModelFiles;
@@ -76,7 +76,7 @@ public class ServerConfiguration {
 		this.includePath = includePath;
 		this.disableGoodFindings = disableGoodFindings;
 		this.additionalLanguages = additionalLanguages;
-		this.disabledMark = disabledMark;
+		this.disabledMarkRules = disabledMarkRules;
 	}
 
 	public static Builder builder() {
@@ -95,7 +95,7 @@ public class ServerConfiguration {
 		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
-		private Map<String, Pair<Boolean, Set<String>>> disabledMark;
+		private Map<String, Pair<Boolean, Set<String>>> disabledMarkRules;
 
 		public Builder launchConsole(boolean launchConsole) {
 			this.launchConsole = launchConsole;
@@ -151,8 +151,8 @@ public class ServerConfiguration {
 			return this;
 		}
 
-		public Builder disableMark(Map<String, Pair<Boolean, Set<String>>> disabledMark) {
-			this.disabledMark = disabledMark;
+		public Builder disableMark(Map<String, Pair<Boolean, Set<String>>> disabledMarkRules) {
+			this.disabledMarkRules = disabledMarkRules;
 			return this;
 		}
 
@@ -167,7 +167,7 @@ public class ServerConfiguration {
 				includePath,
 				disableGoodFindings,
 				additionalLanguages,
-				disabledMark);
+				disabledMarkRules);
 		}
 	}
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -8,6 +8,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** The configuration for the {@link AnalysisServer} holds all values used by the server. */
 public class ServerConfiguration {
@@ -51,6 +53,9 @@ public class ServerConfiguration {
 	/** Additional registered languages */
 	public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages;
 
+	/** Disabled Mark rules */
+	public final Map<String, Pair<Boolean, Set<String>>> disabledMark;
+
 	private ServerConfiguration(
 			boolean launchConsole,
 			boolean launchLsp,
@@ -60,7 +65,8 @@ public class ServerConfiguration {
 			boolean useUnityBuild,
 			@NonNull File[] includePath,
 			boolean disableGoodFindings,
-			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages) {
+			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages,
+			Map<String, Pair<Boolean, Set<String>>> disabledMark) {
 		this.launchConsole = launchConsole;
 		this.launchLsp = launchLsp;
 		this.markModelFiles = markModelFiles;
@@ -70,6 +76,7 @@ public class ServerConfiguration {
 		this.includePath = includePath;
 		this.disableGoodFindings = disableGoodFindings;
 		this.additionalLanguages = additionalLanguages;
+		this.disabledMark = disabledMark;
 	}
 
 	public static Builder builder() {
@@ -88,6 +95,7 @@ public class ServerConfiguration {
 		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
 		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
+		private Map<String, Pair<Boolean, Set<String>>> disabledMark;
 
 		public Builder launchConsole(boolean launchConsole) {
 			this.launchConsole = launchConsole;
@@ -143,6 +151,11 @@ public class ServerConfiguration {
 			return this;
 		}
 
+		public Builder disableMark(Map<String, Pair<Boolean, Set<String>>> disabledMark) {
+			this.disabledMark = disabledMark;
+			return this;
+		}
+
 		public ServerConfiguration build() {
 			return new ServerConfiguration(
 				launchConsole,
@@ -153,7 +166,8 @@ public class ServerConfiguration {
 				useUnityBuild,
 				includePath,
 				disableGoodFindings,
-				additionalLanguages);
+				additionalLanguages,
+				disabledMark);
 		}
 	}
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -69,7 +69,7 @@ class CodyzeConfiguration {
         paramLabel = "<package.rule>",
         description =
             [
-                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by the package and the rule name. Use \'*\' to disable an entire package."],
+                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). Use \'*\' to disable an entire package."],
         split = ","
     )
     var disabledMarkRules: List<String> = emptyList()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -69,7 +69,7 @@ class CodyzeConfiguration {
         paramLabel = "<package.rule>",
         description =
             [
-                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by the package and the rule name."],
+                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by the package and the rule name. Use \'*\' to disable an entire package."],
         split = ","
     )
     var disabledMarkRules: List<String> = emptyList()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -69,7 +69,7 @@ class CodyzeConfiguration {
         paramLabel = "<package.rule>",
         description =
             [
-                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). Use \'*\' to disable an entire package."],
+                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). If there is no package name, specify rule as \".rule\". Use \'*\' to disable an entire package."],
         split = ","
     )
     var disabledMarkRules: List<String> = emptyList()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -74,19 +74,15 @@ class Configuration {
             )
         }
 
-        val disabledRulesMap = mutableMapOf<String, Pair<Boolean, MutableSet<String>>>()
+        val disabledRulesMap = mutableMapOf<String, DisabledMarkRulesValue>()
         for (mName in codyze.disabledMarkRules) {
             val index = mName.lastIndexOf('.')
             val packageName = mName.subSequence(0, index).toString()
             val markName = mName.subSequence(index + 1, mName.length).toString()
-            if (!markName.isEmpty()) {
-                disabledRulesMap.putIfAbsent(packageName, Pair(false, mutableSetOf()))
-                if (markName == "*")
-                    disabledRulesMap.replace(
-                        packageName,
-                        disabledRulesMap.getValue(packageName).copy(first = true)
-                    )
-                else disabledRulesMap[packageName]?.second?.add(markName)
+            if (markName.isNotEmpty()) {
+                disabledRulesMap.putIfAbsent(packageName, DisabledMarkRulesValue())
+                if (markName == "*") disabledRulesMap.getValue(packageName).isDisablePackage = true
+                else disabledRulesMap[packageName]?.disabledMarkRuleNames?.add(markName)
             }
         }
         config.disableMark(disabledRulesMap)

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -106,21 +106,24 @@ class Configuration {
             }
         }
 
-        val disabledRulesMap = mutableMapOf<String, DisabledMarkRulesValue>()
-        for (mName in codyze.disabledMarkRules) {
-            val index = mName.lastIndexOf('.')
-            val packageName = mName.subSequence(0, index).toString()
-            val markName = mName.subSequence(index + 1, mName.length).toString()
-            if (markName.isNotEmpty()) {
-                disabledRulesMap.putIfAbsent(packageName, DisabledMarkRulesValue())
-                if (markName == "*") disabledRulesMap.getValue(packageName).isDisablePackage = true
-                else disabledRulesMap[packageName]?.disabledMarkRuleNames?.add(markName)
-            } else
-                log.warn(
-                    "Error while parsing disabled-mark-rules: \'$mName\' is not a valid name for a mark rule. Continue parsing disabled-mark-rules"
-                )
+        if (!codyze.pedantic) {
+            val disabledRulesMap = mutableMapOf<String, DisabledMarkRulesValue>()
+            for (mName in codyze.disabledMarkRules) {
+                val index = mName.lastIndexOf('.')
+                val packageName = mName.subSequence(0, index).toString()
+                val markName = mName.subSequence(index + 1, mName.length).toString()
+                if (markName.isNotEmpty()) {
+                    disabledRulesMap.putIfAbsent(packageName, DisabledMarkRulesValue())
+                    if (markName == "*")
+                        disabledRulesMap.getValue(packageName).isDisablePackage = true
+                    else disabledRulesMap[packageName]?.disabledMarkRuleNames?.add(markName)
+                } else
+                    log.warn(
+                        "Error while parsing disabled-mark-rules: \'$mName\' is not a valid name for a mark rule. Continue parsing disabled-mark-rules"
+                    )
+            }
+            config.disableMark(disabledRulesMap)
         }
-        config.disableMark(disabledRulesMap)
 
         return config.build()
     }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -83,7 +83,10 @@ class Configuration {
                 disabledRulesMap.putIfAbsent(packageName, DisabledMarkRulesValue())
                 if (markName == "*") disabledRulesMap.getValue(packageName).isDisablePackage = true
                 else disabledRulesMap[packageName]?.disabledMarkRuleNames?.add(markName)
-            }
+            } else
+                log.warn(
+                    "Error while parsing disabled-mark-rules: \'$mName\' is not a valid name for a mark rule. Continue parsing disabled-mark-rules"
+                )
         }
         config.disableMark(disabledRulesMap)
 

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -73,6 +73,24 @@ class Configuration {
                 GoLanguageFrontend.GOLANG_EXTENSIONS
             )
         }
+
+        val disabledRulesMap = mutableMapOf<String, Pair<Boolean, MutableSet<String>>>()
+        for (mName in codyze.disabledMarkRules) {
+            val index = mName.lastIndexOf('.')
+            val packageName = mName.subSequence(0, index).toString()
+            val markName = mName.subSequence(index + 1, mName.length).toString()
+            if (!markName.isEmpty()) {
+                disabledRulesMap.putIfAbsent(packageName, Pair(false, mutableSetOf()))
+                if (markName == "*")
+                    disabledRulesMap.replace(
+                        packageName,
+                        disabledRulesMap.getValue(packageName).copy(first = true)
+                    )
+                else disabledRulesMap[packageName]?.second?.add(markName)
+            }
+        }
+        config.disableMark(disabledRulesMap)
+
         return config.build()
     }
 

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/DisabledMarkRulesValue.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/DisabledMarkRulesValue.kt
@@ -1,0 +1,6 @@
+package de.fraunhofer.aisec.codyze.config
+
+data class DisabledMarkRulesValue(
+    var isDisablePackage: Boolean = false,
+    val disabledMarkRuleNames: MutableSet<String> = mutableSetOf()
+)

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/DisabledMarkRulesValue.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/DisabledMarkRulesValue.kt
@@ -1,8 +1,7 @@
 package de.fraunhofer.aisec.codyze.config
 
 /**
- * Stores whether the associated package should be disabled and the name of the rules that should be
- * disabled
+ * Stores whether the associated package should be disabled and the name of the rules to be disabled
  */
 data class DisabledMarkRulesValue(
     var isDisablePackage: Boolean = false,

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/DisabledMarkRulesValue.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/DisabledMarkRulesValue.kt
@@ -1,5 +1,9 @@
 package de.fraunhofer.aisec.codyze.config
 
+/**
+ * Stores whether the associated package should be disabled and the name of the rules that should be
+ * disabled
+ */
 data class DisabledMarkRulesValue(
     var isDisablePackage: Boolean = false,
     val disabledMarkRuleNames: MutableSet<String> = mutableSetOf()

--- a/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
@@ -2,6 +2,7 @@
 package de.fraunhofer.aisec.codyze.markmodel;
 
 import de.fraunhofer.aisec.codyze.analysis.markevaluation.ExpressionHelper;
+import de.fraunhofer.aisec.codyze.config.DisabledMarkRulesValue;
 import de.fraunhofer.aisec.mark.markDsl.EntityDeclaration;
 import de.fraunhofer.aisec.mark.markDsl.EntityStatement;
 import de.fraunhofer.aisec.mark.markDsl.MarkModel;
@@ -27,7 +28,7 @@ public class MarkModelLoader {
 	private static final Logger log = LoggerFactory.getLogger(MarkModelLoader.class);
 
 	@NonNull
-	public Mark load(Map<String, MarkModel> markModels, Map<String, Pair<Boolean, Set<String>>> disabledMarkRules, @Nullable String onlyfromthisfile) {
+	public Mark load(Map<String, MarkModel> markModels, Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules, @Nullable String onlyfromthisfile) {
 		Mark m = new Mark();
 
 		for (Map.Entry<String, MarkModel> entry : markModels.entrySet()) {
@@ -55,8 +56,9 @@ public class MarkModelLoader {
 				continue;
 			}
 			MarkModel markModel = entry.getValue();
-			Pair<Boolean, Set<String>> disabledRules = disabledMarkRules.getOrDefault(markModel.getPackage().getName(), new Pair<>(false, new HashSet<>()));
-			if (disabledRules.getFirst()) {
+			DisabledMarkRulesValue disabledRules = packageToDisabledMarkRules.getOrDefault(markModel.getPackage().getName(),
+				new DisabledMarkRulesValue(false, new HashSet<>()));
+			if (disabledRules.isDisablePackage()) {
 				log.info("Disabled all mark rules in package {}", markModel.getPackage().getName());
 				continue;
 			}
@@ -65,7 +67,7 @@ public class MarkModelLoader {
 			for (RuleDeclaration r : markModel.getRule()) {
 				// todo @FW: should rules also have package names? what is the exact reasoning behind
 				// packages?
-				if (disabledRules.getSecond().contains(r.getName())) {
+				if (disabledRules.getDisabledMarkRuleNames().contains(r.getName())) {
 					log.info("Disabled mark rule {} in package {}", r.getName(), markModel.getPackage().getName());
 					continue;
 				}
@@ -103,8 +105,8 @@ public class MarkModelLoader {
 	}
 
 	@NonNull
-	public Mark load(Map<String, MarkModel> markModels, Map<String, Pair<Boolean, Set<String>>> disabledMarkRules) {
-		return load(markModels, disabledMarkRules, null);
+	public Mark load(Map<String, MarkModel> markModels, Map<String, DisabledMarkRulesValue> packageToDisabledMarkRules) {
+		return load(markModels, packageToDisabledMarkRules, null);
 	}
 
 	@NonNull

--- a/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
@@ -78,7 +78,7 @@ public class MarkModelLoader {
 
 				// check if rule should be disabled
 				if (disabledRules.getDisabledMarkRuleNames().contains(r.getName())) {
-					log.info("Disabled mark rule {} in package {}", r.getName(), markModel.getPackage().getName());
+					log.info("Disabled mark rule {} in package {}", r.getName(), markModel.getPackage() == null ? "" : markModel.getPackage().getName());
 					continue;
 				}
 

--- a/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
@@ -57,8 +57,14 @@ public class MarkModelLoader {
 			}
 			MarkModel markModel = entry.getValue();
 
-			DisabledMarkRulesValue disabledRules = packageToDisabledMarkRules.getOrDefault(markModel.getPackage().getName(),
-				new DisabledMarkRulesValue(false, new HashSet<>()));
+			DisabledMarkRulesValue disabledRules;
+			if (markModel.getPackage() == null) {
+				disabledRules = packageToDisabledMarkRules.getOrDefault("", new DisabledMarkRulesValue(false, new HashSet<>()));
+			} else {
+				disabledRules = packageToDisabledMarkRules.getOrDefault(markModel.getPackage().getName(),
+					new DisabledMarkRulesValue(false, new HashSet<>()));
+			}
+
 			// check if entire package should be disabled
 			if (disabledRules.isDisablePackage()) {
 				log.info("Disabled all mark rules in package {}", markModel.getPackage().getName());

--- a/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/markmodel/MarkModelLoader.java
@@ -56,8 +56,10 @@ public class MarkModelLoader {
 				continue;
 			}
 			MarkModel markModel = entry.getValue();
+
 			DisabledMarkRulesValue disabledRules = packageToDisabledMarkRules.getOrDefault(markModel.getPackage().getName(),
 				new DisabledMarkRulesValue(false, new HashSet<>()));
+			// check if entire package should be disabled
 			if (disabledRules.isDisablePackage()) {
 				log.info("Disabled all mark rules in package {}", markModel.getPackage().getName());
 				continue;
@@ -67,6 +69,8 @@ public class MarkModelLoader {
 			for (RuleDeclaration r : markModel.getRule()) {
 				// todo @FW: should rules also have package names? what is the exact reasoning behind
 				// packages?
+
+				// check if rule should be disabled
 				if (disabledRules.getDisabledMarkRuleNames().contains(r.getName())) {
 					log.info("Disabled mark rule {} in package {}", r.getName(), markModel.getPackage().getName());
 					continue;

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkLoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/MarkLoadTest.kt
@@ -1,0 +1,173 @@
+package de.fraunhofer.aisec.codyze.crymlin
+
+import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
+import de.fraunhofer.aisec.codyze.config.DisabledMarkRulesValue
+import de.fraunhofer.aisec.codyze.markmodel.MRule
+import java.io.File
+import java.lang.Exception
+import kotlin.Throws
+import kotlin.test.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Test
+
+internal class MarkLoadTest {
+
+    @Test
+    @Throws(Exception::class)
+    fun disabledRulesTest() {
+        val disabledMarkRules = mutableMapOf<String, DisabledMarkRulesValue>()
+        disabledMarkRules["java"] =
+            DisabledMarkRulesValue(
+                false,
+                mutableSetOf("UseValidAlgorithm", "RandomInitializationVector", "MockWhen2")
+            )
+
+        analysisServer.loadMarkRules(disabledMarkRules, botanLocation, javaLocation)
+        val actualMarkRules = analysisServer.markModel.rules
+        assertNotNull(actualMarkRules)
+        val actualMarkRuleNames = actualMarkRules.map { r -> r.name }
+
+        assertFalse(actualMarkRuleNames.isEmpty(), "Expected to contain mark rules but was empty")
+
+        val expectedSize =
+            allMarkRules.size -
+                disabledMarkRules.getOrDefault("java", DisabledMarkRulesValue())
+                    .disabledMarkRuleNames
+                    .size
+        assertEquals(
+            expectedSize,
+            actualMarkRuleNames.size,
+            "Expected size to be $expectedSize, but was ${actualMarkRuleNames.size}"
+        )
+
+        for (s in
+            disabledMarkRules.getOrDefault("java", DisabledMarkRulesValue())
+                .disabledMarkRuleNames) assertFalse(
+            actualMarkRuleNames.contains(s),
+            "Expected to have filtered out $s but was included in mark rules"
+        )
+
+        for (s in botanMarkRuleNames) assertTrue(
+            actualMarkRuleNames.contains(s),
+            "Expected to have loaded $s but was not in mark rules"
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun disabledPackageTest() {
+        val disabledMarkRules = mutableMapOf<String, DisabledMarkRulesValue>()
+        disabledMarkRules["botan"] = DisabledMarkRulesValue(true, mutableSetOf())
+
+        analysisServer.loadMarkRules(disabledMarkRules, botanLocation, javaLocation)
+        val actualMarkRules = analysisServer.markModel.rules
+        assertNotNull(actualMarkRules)
+        val actualMarkRuleNames = actualMarkRules.map { r -> r.name }
+
+        assertFalse(actualMarkRuleNames.isEmpty(), "Expected to contain mark rules but was empty")
+
+        val expectedSize = allMarkRules.size - botanMarkRuleNames.size
+        assertEquals(
+            expectedSize,
+            actualMarkRuleNames.size,
+            "Expected size to be $expectedSize, but was ${actualMarkRuleNames.size}"
+        )
+
+        for (s in botanMarkRuleNames) assertFalse(
+            actualMarkRuleNames.contains(s),
+            "Expected to have filtered out $s but was included in mark rules"
+        )
+
+        for (s in javaMarkRuleNames) assertTrue(
+            actualMarkRuleNames.contains(s),
+            "Expected to have loaded $s but was not in mark rules"
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun disabledRulesAndPackageTest() {
+        val disabledMarkRules = mutableMapOf<String, DisabledMarkRulesValue>()
+        disabledMarkRules["java"] =
+            DisabledMarkRulesValue(
+                false,
+                mutableSetOf("UseValidAlgorithm", "RandomInitializationVector", "MockWhen2")
+            )
+        disabledMarkRules["botan"] = DisabledMarkRulesValue(true, mutableSetOf())
+
+        analysisServer.loadMarkRules(disabledMarkRules, botanLocation, javaLocation)
+        val actualMarkRules = analysisServer.markModel.rules
+        assertNotNull(actualMarkRules)
+        val actualMarkRuleNames = actualMarkRules.map { r -> r.name }
+
+        assertFalse(actualMarkRuleNames.isEmpty(), "Expected to contain mark rules but was empty")
+
+        val expectedSize =
+            allMarkRules.size -
+                disabledMarkRules.getOrDefault("java", DisabledMarkRulesValue())
+                    .disabledMarkRuleNames
+                    .size -
+                botanMarkRuleNames.size
+        assertEquals(
+            expectedSize,
+            actualMarkRuleNames.size,
+            "Expected size to be $expectedSize, but was ${actualMarkRuleNames.size}"
+        )
+
+        for (s in
+            disabledMarkRules.getOrDefault("java", DisabledMarkRulesValue())
+                .disabledMarkRuleNames) assertFalse(
+            actualMarkRuleNames.contains(s),
+            "Expected to have filtered out $s but was included in mark rules"
+        )
+
+        for (s in botanMarkRuleNames) assertFalse(
+            actualMarkRuleNames.contains(s),
+            "Expected to have filtered out $s but was included in mark rules"
+        )
+    }
+
+    companion object {
+        private lateinit var analysisServer: AnalysisServer
+        private lateinit var javaLocation: File
+        private lateinit var botanLocation: File
+        private lateinit var allMarkRules: MutableList<MRule>
+        private lateinit var botanMarkRuleNames: List<String>
+        private lateinit var javaMarkRuleNames: List<String>
+
+        @BeforeAll
+        @JvmStatic
+        fun startup() {
+            analysisServer = AnalysisServer.builder().build()
+            assertNotNull(analysisServer)
+
+            val botanMarkResource =
+                MarkLoadTest::class.java.classLoader.getResource("real-examples/botan/MARK")
+            assertNotNull(botanMarkResource)
+            botanLocation = File(botanMarkResource.file)
+            assertNotNull(botanLocation)
+
+            val javaMarkResource =
+                MarkLoadTest::class.java.classLoader.getResource(
+                    "real-examples/bc/rwedoff.Password-Manager"
+                )
+            assertNotNull(javaMarkResource)
+            javaLocation = File(javaMarkResource.file)
+            assertNotNull(javaLocation)
+
+            analysisServer.loadMarkRules(botanLocation, javaLocation)
+            allMarkRules = analysisServer.markModel.rules
+            assertNotNull(allMarkRules)
+
+            analysisServer.loadMarkRules(botanLocation)
+            val botanMarkRules = analysisServer.markModel.rules
+            assertNotNull(botanMarkRules)
+            botanMarkRuleNames = botanMarkRules.map { r -> r.name }
+
+            analysisServer.loadMarkRules(javaLocation)
+            val javaMarkRules = analysisServer.markModel.rules
+            assertNotNull(javaMarkRules)
+            javaMarkRuleNames = javaMarkRules.map { r -> r.name }
+        }
+    }
+}

--- a/src/test/java/de/fraunhofer/aisec/cpg/analysis/fsm/FSMBuilderTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/cpg/analysis/fsm/FSMBuilderTest.kt
@@ -24,7 +24,7 @@ class FSMBuilderTest {
         val parser = XtextParser()
         parser.addMarkFile(markPoC1)
         val markModels = parser.parse()
-        val mark = MarkModelLoader().load(markModels, null)
+        val mark = MarkModelLoader().load(markModels)
         assertNotNull(mark)
         var dfa = DFA()
         for (rule in mark.rules) {
@@ -55,7 +55,7 @@ class FSMBuilderTest {
         val parser = XtextParser()
         parser.addMarkFile(markPoC1)
         val markModels = parser.parse()
-        val mark = MarkModelLoader().load(markModels, null)
+        val mark = MarkModelLoader().load(markModels)
         assertNotNull(mark)
         var dfa = DFA()
         for (rule in mark.rules) {
@@ -97,7 +97,7 @@ class FSMBuilderTest {
         val parser = XtextParser()
         parser.addMarkFile(markPoC1)
         val markModels = parser.parse()
-        val mark = MarkModelLoader().load(markModels, null)
+        val mark = MarkModelLoader().load(markModels)
         assertNotNull(mark)
         var dfa = DFA()
         for (rule in mark.rules) {
@@ -143,7 +143,7 @@ class FSMBuilderTest {
         val parser = XtextParser()
         parser.addMarkFile(markPoC1)
         val markModels = parser.parse()
-        val mark = MarkModelLoader().load(markModels, null)
+        val mark = MarkModelLoader().load(markModels)
         assertNotNull(mark)
         for (rule in mark.rules) {
             if (rule.statement.ensure.exp is OrderExpression) {


### PR DESCRIPTION
This PR adds the possibility to exclude mark rules from being loaded. The disabled mark rules are specified as fully qualified name (package.markRuleName) either in the configuration file or as a CLI option. The asterisk (*) is used as a wildcard to disable an entire package.