### PR TITLE
Seperate ServerConfiguration and TranslationConfiguration

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -99,8 +99,7 @@ public class Main {
 		}
 
 		AnalysisServer server = AnalysisServer.builder()
-				.config(configuration
-						.buildServerConfiguration())
+				.config(configuration)
 				.build();
 
 		server.start();

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
@@ -365,11 +365,8 @@ public class AnalysisServer {
 	}
 
 	public CompletableFuture<AnalysisContext> analyze(String url) {
-		List<File> files = new ArrayList<>();
-		files.add(new File(url));
-
 		var translationManager = TranslationManager.builder()
-				.config(config.buildTranslationConfiguration(files))
+				.config(config.buildTranslationConfiguration(new File(url)))
 				.build();
 
 		return analyze(translationManager);

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/ServerConfiguration.java
@@ -26,50 +26,20 @@ public class ServerConfiguration {
 	@NonNull
 	public final TypestateMode typestateAnalysis;
 
-	/**
-	 * Passed down to {@link de.fraunhofer.aisec.cpg.TranslationConfiguration}. Whether to
-	 * parse include files.
-	 */
-	public final boolean analyzeIncludes;
-
-	/**
-	 * Enables or disables unity builds (for C++ only).
-	 */
-	public final boolean useUnityBuild;
-
-	/**
-	 * Path(s) containing include files.
-	 *
-	 * <p>Paths must be separated by File.pathSeparator (: or ;).
-	 */
-	@NonNull
-	public final File[] includePath;
-
 	/** If true, no "positive" findings will be returned from the analysis. */
 	public final boolean disableGoodFindings;
-
-	/** Additional registered languages */
-	public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages;
 
 	private ServerConfiguration(
 			boolean launchConsole,
 			boolean launchLsp,
 			@NonNull String[] markModelFiles,
 			@NonNull TypestateMode typestateMode,
-			boolean analyzeIncludes,
-			boolean useUnityBuild,
-			@NonNull File[] includePath,
-			boolean disableGoodFindings,
-			List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages) {
+			boolean disableGoodFindings) {
 		this.launchConsole = launchConsole;
 		this.launchLsp = launchLsp;
 		this.markModelFiles = markModelFiles;
 		this.typestateAnalysis = typestateMode;
-		this.analyzeIncludes = analyzeIncludes;
-		this.useUnityBuild = useUnityBuild;
-		this.includePath = includePath;
 		this.disableGoodFindings = disableGoodFindings;
-		this.additionalLanguages = additionalLanguages;
 	}
 
 	public static Builder builder() {
@@ -83,11 +53,7 @@ public class ServerConfiguration {
 		private String[] markModelFiles = new String[0]; // Path of a file or directory
 		@NonNull
 		private TypestateMode typestateAnalysis = TypestateMode.DFA;
-		private boolean analyzeIncludes;
-		private boolean useUnityBuild;
-		private File[] includePath = new File[0];
 		private boolean disableGoodFindings;
-		public final List<Pair<Class<? extends LanguageFrontend>, List<String>>> additionalLanguages = new ArrayList<>();
 
 		public Builder launchConsole(boolean launchConsole) {
 			this.launchConsole = launchConsole;
@@ -109,31 +75,6 @@ public class ServerConfiguration {
 			return this;
 		}
 
-		public Builder analyzeIncludes(boolean analyzeIncludes) {
-			this.analyzeIncludes = analyzeIncludes;
-			return this;
-		}
-
-		public Builder useUnityBuild(boolean useUnityBuild) {
-			this.useUnityBuild = useUnityBuild;
-			return this;
-		}
-
-		public Builder includePath(File[] includePath) {
-			if (includePath == null) {
-				this.includePath = new File[0];
-			} else {
-				this.includePath = includePath;
-			}
-
-			return this;
-		}
-
-		public Builder registerLanguage(Class<? extends LanguageFrontend> clazz, List<String> fileExtensions) {
-			this.additionalLanguages.add(new Pair<>(clazz, fileExtensions));
-			return this;
-		}
-
 		public Builder disableGoodFindings(boolean disableGoodFindings) {
 			this.disableGoodFindings = disableGoodFindings;
 			return this;
@@ -149,11 +90,7 @@ public class ServerConfiguration {
 				launchLsp,
 				markModelFiles,
 				typestateAnalysis,
-				analyzeIncludes,
-				useUnityBuild,
-				includePath,
-				disableGoodFindings,
-				additionalLanguages);
+				disableGoodFindings);
 		}
 	}
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -83,7 +83,7 @@ class Configuration {
      */
     @ExperimentalGolang
     @ExperimentalPython
-    fun buildTranslationConfiguration(sources : List<File> ): TranslationConfiguration {
+    fun buildTranslationConfiguration(vararg sources: File): TranslationConfiguration {
         val translationConfig =
             TranslationConfiguration.builder()
                 .debugParser(true)
@@ -95,7 +95,7 @@ class Configuration {
                 .defaultLanguages()
                 .registerPass(IdentifierPass())
                 .registerPass(EdgeCachePass())
-                .sourceLocations(sources)
+                .sourceLocations(*sources)
         if (cpg.additionalLanguages.contains(Language.PYTHON) || cpg.enablePython) {
             translationConfig.registerLanguage(
                 PythonLanguageFrontend::class.java,

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -23,8 +23,8 @@ import picocli.CommandLine
 class Configuration {
 
     // Added as Mixin so the already initialized objects are used instead of new ones created
-    @CommandLine.Mixin var codyze = CodyzeConfiguration()
-    @CommandLine.Mixin var cpg = CpgConfiguration()
+    @CommandLine.Mixin val codyze = CodyzeConfiguration()
+    @CommandLine.Mixin val cpg = CpgConfiguration()
 
     // Parse CLI arguments into config class
     private fun parseCLI(vararg args: String?) {
@@ -50,30 +50,13 @@ class Configuration {
     @ExperimentalGolang
     @ExperimentalPython
     fun buildServerConfiguration(): ServerConfiguration {
-        val config =
-            ServerConfiguration.builder()
-                .launchLsp(codyze.executionMode.isLsp)
-                .launchConsole(codyze.executionMode.isTui)
-                .typestateAnalysis(codyze.analysis.tsMode)
-                .disableGoodFindings(codyze.noGoodFindings)
-                .markFiles(*codyze.mark.map { m -> m.absolutePath }.toTypedArray())
-                // TODO: remove all cpg config and replace with TranslationConfiguration
-                .analyzeIncludes(cpg.translation.analyzeIncludes)
-                .includePath(cpg.translation.includes)
-                .useUnityBuild(cpg.useUnityBuild)
-        if (cpg.additionalLanguages.contains(Language.PYTHON) || cpg.enablePython) {
-            config.registerLanguage(
-                PythonLanguageFrontend::class.java,
-                PythonLanguageFrontend.PY_EXTENSIONS
-            )
-        }
-        if (cpg.additionalLanguages.contains(Language.GO) || cpg.enableGo) {
-            config.registerLanguage(
-                GoLanguageFrontend::class.java,
-                GoLanguageFrontend.GOLANG_EXTENSIONS
-            )
-        }
-        return config.build()
+        return ServerConfiguration.builder()
+            .launchLsp(codyze.executionMode.isLsp)
+            .launchConsole(codyze.executionMode.isTui)
+            .typestateAnalysis(codyze.analysis.tsMode)
+            .disableGoodFindings(codyze.noGoodFindings)
+            .markFiles(*codyze.mark.map { m -> m.absolutePath }.toTypedArray())
+            .build()
     }
 
     /**

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -126,7 +126,7 @@ class Configuration {
                 config = mapper.readValue(configFile, Configuration::class.java)
             } catch (e: UnrecognizedPropertyException) {
                 printErrorMessage(
-                        "Could not parse configuration file correctly because \"${e.propertyName}\" is not a valid argument name for ${e.path[0].fieldName} configurations."
+                    "Could not parse configuration file correctly because \"${e.propertyName}\" is not a valid argument name for ${e.path[0].fieldName} configurations."
                 )
             } catch (e: FileNotFoundException) {
                 printErrorMessage("File at ${configFile.absolutePath} not found.")

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -126,14 +126,10 @@ class Configuration {
                 config = mapper.readValue(configFile, Configuration::class.java)
             } catch (e: UnrecognizedPropertyException) {
                 printErrorMessage(
-                    String.format(
-                        "Could not parse configuration file correctly because %s is not a valid argument name for %s configurations.",
-                        e.propertyName,
-                        e.path[0].fieldName
-                    )
+                        "Could not parse configuration file correctly because \"${e.propertyName}\" is not a valid argument name for ${e.path[0].fieldName} configurations."
                 )
             } catch (e: FileNotFoundException) {
-                printErrorMessage(String.format("File at %s not found.", configFile.absolutePath))
+                printErrorMessage("File at ${configFile.absolutePath} not found.")
             } catch (e: IOException) {
                 printErrorMessage(e.message)
             }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -83,9 +83,7 @@ class Configuration {
      */
     @ExperimentalGolang
     @ExperimentalPython
-    fun buildTranslationConfiguration(): TranslationConfiguration {
-        val files: MutableList<File> = ArrayList()
-        files.add(File(codyze.source!!.absolutePath))
+    fun buildTranslationConfiguration(sources : List<File> ): TranslationConfiguration {
         val translationConfig =
             TranslationConfiguration.builder()
                 .debugParser(true)
@@ -97,7 +95,7 @@ class Configuration {
                 .defaultLanguages()
                 .registerPass(IdentifierPass())
                 .registerPass(EdgeCachePass())
-                .sourceLocations(*files.toTypedArray())
+                .sourceLocations(sources)
         if (cpg.additionalLanguages.contains(Language.PYTHON) || cpg.enablePython) {
             translationConfig.registerLanguage(
                 PythonLanguageFrontend::class.java,

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -69,5 +69,5 @@ class TranslationSettings {
                 "Path(s) containing include files. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
         split = ":|;"
     )
-    var includes: Array<File>? = null
+    var includes: Array<File>? = emptyArray()
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -69,5 +69,5 @@ class TranslationSettings {
                 "Path(s) containing include files. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
         split = ":|;"
     )
-    var includes: Array<File>? = emptyArray()
+    var includes: Array<File> = emptyArray()
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/crymlin/connectors/lsp/CpgDocumentService.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/crymlin/connectors/lsp/CpgDocumentService.java
@@ -87,7 +87,7 @@ public class CpgDocumentService implements TextDocumentService {
 							.build())
 				.build();
 
-		CompletableFuture<AnalysisContext> analyze = instance.analyze(tm);
+		CompletableFuture<AnalysisContext> analyze = instance.analyze(file.getAbsolutePath());
 
 		try {
 			AnalysisContext ctx = analyze.get(5, TimeUnit.MINUTES);

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AbstractMarkTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AbstractMarkTest.kt
@@ -3,8 +3,8 @@ package de.fraunhofer.aisec.codyze.crymlin
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
 import de.fraunhofer.aisec.codyze.analysis.Finding
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
 import de.fraunhofer.aisec.codyze.analysis.TypestateMode
+import de.fraunhofer.aisec.codyze.config.Configuration
 import de.fraunhofer.aisec.cpg.TranslationManager
 import java.io.*
 import java.lang.Exception
@@ -78,18 +78,13 @@ abstract class AbstractMarkTest : AbstractTest() {
                 .toTypedArray()
 
         // Start an analysis server
-        server =
-            AnalysisServer.builder()
-                .config(
-                    ServerConfiguration.builder()
-                        .launchConsole(false)
-                        .launchLsp(false)
-                        .typestateAnalysis(tsMode)
-                        .markFiles(*markDirPaths)
-                        .useLegacyEvaluator()
-                        .build()
-                )
-                .build()
+        val config = Configuration()
+        config.codyze.executionMode.isCli = false
+        config.codyze.executionMode.isLsp = false
+        config.codyze.analysis.tsMode = tsMode
+        config.codyze.mark = markDirPaths.map { s -> File(s) }.toTypedArray()
+
+        server = AnalysisServer.builder().config(config).build()
         server.start()
         translationManager = newAnalysisRun(*toAnalyze.toTypedArray())
         val analyze = server.analyze(translationManager)

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AnalysisServerBotanTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AnalysisServerBotanTest.kt
@@ -2,7 +2,7 @@ package de.fraunhofer.aisec.codyze.crymlin
 
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
+import de.fraunhofer.aisec.codyze.config.Configuration
 import java.io.*
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -59,16 +59,12 @@ internal class AnalysisServerBotanTest : AbstractTest() {
             val markModelFiles = markPoC1.parent
 
             // Start an analysis server
-            server =
-                AnalysisServer.builder()
-                    .config(
-                        ServerConfiguration.builder()
-                            .launchConsole(false)
-                            .launchLsp(false)
-                            .markFiles(markModelFiles)
-                            .build()
-                    )
-                    .build()
+            val config = Configuration()
+            config.codyze.executionMode.isCli = false
+            config.codyze.executionMode.isLsp = false
+            config.codyze.mark = arrayOf(File(markModelFiles))
+
+            server = AnalysisServer.builder().config(config).build()
             server.start()
 
             // Start the analysis (BOTAN Symmetric Example by Oliver)

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AnalysisServerQueriesTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/AnalysisServerQueriesTest.kt
@@ -2,7 +2,7 @@ package de.fraunhofer.aisec.codyze.crymlin
 
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
+import de.fraunhofer.aisec.codyze.config.Configuration
 import java.io.*
 import java.lang.Exception
 import java.util.concurrent.TimeUnit
@@ -43,16 +43,12 @@ internal class AnalysisServerQueriesTest : AbstractTest() {
             val markModelFiles = markPoC1.parent
 
             // Start an analysis server
-            server =
-                AnalysisServer.builder()
-                    .config(
-                        ServerConfiguration.builder()
-                            .launchConsole(false)
-                            .launchLsp(false)
-                            .markFiles(markModelFiles)
-                            .build()
-                    )
-                    .build()
+            val config = Configuration()
+            config.codyze.executionMode.isCli = false
+            config.codyze.executionMode.isLsp = false
+            config.codyze.mark = arrayOf(File(markModelFiles))
+
+            server = AnalysisServer.builder().config(config).build()
             server.start()
 
             // Start the analysis

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
@@ -48,8 +48,8 @@ internal class CLILoadTest {
         assertFalse(codyze.sarifOutput)
 
         assertFalse(cpg.translation.analyzeIncludes)
-        assertNull(cpg.translation.includes)
-        assertEquals(0, cpg.additionalLanguages.size, "Set of additional languages is not empty")
+        assertEquals(0, cpg.translation.includes.size, "Array of includes was not empty")
+        assertEquals(0, cpg.additionalLanguages.size, "Set of additional languages was not empty")
         assertFalse(cpg.useUnityBuild)
     }
 }

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CommandsTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CommandsTest.kt
@@ -3,8 +3,8 @@ package de.fraunhofer.aisec.codyze.crymlin
 import de.fraunhofer.aisec.codyze.Commands
 import de.fraunhofer.aisec.codyze.JythonInterpreter
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
 import de.fraunhofer.aisec.codyze.analysis.TypestateMode
+import de.fraunhofer.aisec.codyze.config.Configuration
 import java.io.*
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.*
@@ -13,18 +13,13 @@ import org.junit.jupiter.api.*
 internal class CommandsTest {
     @Test
     fun commandConsoleTest() {
-        val server =
-            AnalysisServer.builder()
-                .config(
-                    ServerConfiguration.builder()
-                        .launchLsp(false)
-                        .launchConsole(true)
-                        .typestateAnalysis(TypestateMode.DFA)
-                        .markFiles(File("src/test/resources/mark_java").absolutePath)
-                        .useLegacyEvaluator()
-                        .build()
-                )
-                .build()
+        val config = Configuration()
+        config.codyze.executionMode.isLsp = false
+        config.codyze.executionMode.isCli = true
+        config.codyze.analysis.tsMode = TypestateMode.DFA
+        config.codyze.mark = arrayOf(File("src/test/resources/mark_java"))
+
+        val server = AnalysisServer.builder().config(config).build()
         server.start()
         val oldOut = System.out
         val oldErr = System.err

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigLoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigLoadTest.kt
@@ -63,7 +63,7 @@ internal class ConfigLoadTest {
         assertFalse(codyze.sarifOutput)
 
         assertFalse(cpg.translation.analyzeIncludes)
-        assertNull(cpg.translation.includes)
+        assertEquals(0, cpg.translation.includes.size, "Array of includes was not empty")
         assertEquals(0, cpg.additionalLanguages.size, "Set of additional languages is not empty")
         assertFalse(cpg.useUnityBuild)
     }

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/GithubTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/GithubTest.kt
@@ -1,7 +1,7 @@
 package de.fraunhofer.aisec.codyze.crymlin
 
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
+import de.fraunhofer.aisec.codyze.config.Configuration
 import java.io.*
 import java.lang.Exception
 import java.nio.charset.StandardCharsets
@@ -58,16 +58,12 @@ internal class GithubTest : AbstractTest() {
             val markPoC1 = File(resource.file)
             assertNotNull(markPoC1)
 
-            server =
-                AnalysisServer.builder()
-                    .config(
-                        ServerConfiguration.builder()
-                            .launchConsole(false)
-                            .launchLsp(false)
-                            .markFiles(markPoC1.absolutePath)
-                            .build()
-                    )
-                    .build()
+            val config = Configuration()
+            config.codyze.executionMode.isCli = false
+            config.codyze.executionMode.isLsp = false
+            config.codyze.mark = arrayOf(markPoC1)
+
+            server = AnalysisServer.builder().config(config).build()
             server.start()
             logCopy = TestAppender("logCopy", null)
             logCopy!!.injectIntoLogger()

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/GraphTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/GraphTest.kt
@@ -2,8 +2,8 @@ package de.fraunhofer.aisec.codyze.crymlin
 
 import de.fraunhofer.aisec.codyze.analysis.AnalysisContext
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
 import de.fraunhofer.aisec.codyze.analysis.markevaluation.*
+import de.fraunhofer.aisec.codyze.config.Configuration
 import de.fraunhofer.aisec.cpg.ExperimentalGraph
 import de.fraunhofer.aisec.cpg.graph.Graph
 import de.fraunhofer.aisec.cpg.graph.declarations.TypedefDeclaration
@@ -131,12 +131,11 @@ internal class GraphTest : AbstractTest() {
             assertNotNull(cppFile)
 
             // Start an analysis server
-            server =
-                AnalysisServer.builder()
-                    .config(
-                        ServerConfiguration.builder().launchConsole(false).launchLsp(false).build()
-                    )
-                    .build()
+            val config = Configuration()
+            config.codyze.executionMode.isCli = false
+            config.codyze.executionMode.isLsp = false
+
+            server = AnalysisServer.builder().config(config).build()
             server.start()
 
             // Start the analysis

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/LSPTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/LSPTest.kt
@@ -1,7 +1,7 @@
 package de.fraunhofer.aisec.codyze.crymlin
 
 import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
+import de.fraunhofer.aisec.codyze.config.Configuration
 import java.io.*
 import java.nio.file.Paths
 import java.util.concurrent.CompletableFuture
@@ -105,16 +105,12 @@ internal class LSPTest {
             parentFolder = markPoC1.parent + File.separator
 
             // Start an analysis server
-            server =
-                AnalysisServer.builder()
-                    .config(
-                        ServerConfiguration.builder()
-                            .launchConsole(false)
-                            .launchLsp(true)
-                            .markFiles(parentFolder)
-                            .build()
-                    )
-                    .build()
+            val config = Configuration()
+            config.codyze.executionMode.isCli = false
+            config.codyze.executionMode.isLsp = true
+            config.codyze.mark = arrayOf(File(parentFolder))
+
+            server = AnalysisServer.builder().config(config).build()
             server.start()
         }
     }


### PR DESCRIPTION
This PR changes the AnalysisServer to use the buildTranslationConfiguration and buildServerConfiguration function of the Configuration class to build the TranslationConfiguration and ServerConfiguration object. All CPG configurations are removed from the ServerConfiguration class.