### PR TITLE
Add schema for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,42 +29,10 @@ $ cd build/install/codyze
 $ ./bin/codyze
 ```
 
-Without further command line arguments, Codyze will print its command line help:
+Codyze can be configured with either command line arguments or a YAML configuration file.
 
+For further information about the configurations, please refer to the [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage) and https://www.codyze.io.
 
-```
-Usage: codyze (-c | -l | -t) [[--typestate=<NFA|WPDS>]] [[--analyze-includes]
-              [--includes=<includesPath>[:|;<includesPath>...]] [--includes=<includesPath>[:|;
-              <includesPath>...]]...] [-hV] [--no-good-findings] [-m=<path>] [-o=<file>]
-              [-s=<path>] [--timeout=<minutes>]
-Codyze finds security flaws in source code
-  -s, --source=<path>       Source file or folder to analyze.
-  -m, --mark=<path>         Load MARK policy files from folder
-  -o, --output=<file>       Write results to file. Use -- for stdout.
-      --timeout=<minutes>   Terminate analysis after timeout
-                              Default: 120
-      --no-good-findings    Disable output of "positive" findings which indicate correct
-                              implementations
-  -h, --help                Show this help message and exit.
-  -V, --version             Print version information and exit.
-Execution mode
-  -c                        Start in command line mode.
-  -l                        Start in language server protocol (LSP) mode.
-  -t                        Start interactive console (Text-based User Interface).
-Analysis settings
-      --typestate=<NFA|WPDS>
-                            Typestate analysis mode
-                            NFA:  Non-deterministic finite automaton (faster, intraprocedural)
-                            WPDS: Weighted pushdown system (slower, interprocedural)
-Translation settings
-      --analyze-includes    Enables parsing of include files. By default, if --includes are given,
-                              the parser will resolve symbols/templates from these include, but not
-                              load their parse tree.
-      --includes=<includesPath>[:|;<includesPath>...]
-                            Path(s) containing include files. Path must be separated by :
-                              (Mac/Linux) or ; (Windows)
-```
-Please refer to https://www.codyze.io for further usage instructions.
 
 ## Research & Student Work
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ $ ./gradlew installDist
 This will provide you with an executable Codyze installation under `build/install/codyze`.
 To start Codyze, change to the directory and run Codyze.
 
-Codyze has three execution modes, commando line interface mode, language server protocol mode and interactive console mode.
+Codyze has three execution modes:
+* commando line interface mode (`-c`)
+* language server protocol mode (`-l`)
+* interactive console mode (`-t`).
+
 One of these modes has to be specified as command line option when running Codyze.
+
 An exemplary call to start the interactive console mode would be:
 
 ```shell
@@ -35,7 +40,7 @@ $ ./bin/codyze -t
 ```
 
 Codyze can be further configured with more command line arguments or a YAML configuration file.
-For more information about the usage and configurations, please refer to https://www.codyze.io and the [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage).
+For more information about the usage and configurations, please refer to https://www.codyze.io and the corresponding [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage).
 
 
 ## Research & Student Work

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Codyze has three execution modes:
 
 One of these modes has to be specified as command line option when running Codyze.
 
-An exemplary call to start the interactive console mode would be:
+An exemplary call to start the commando line interface mode would be
 
 ```shell
 $ cd build/install/codyze
-$ ./bin/codyze -t
+$ ./bin/codyze -c -m ./mark -s <sourcepath>
 ```
+where `<sourcepath>` denotes the path to the source directory or file.
 
 Codyze can be further configured with more command line arguments or a YAML configuration file.
 For more information about the usage and configurations, please refer to https://www.codyze.io and the corresponding [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ An exemplary call to start the commando line interface mode would be
 $ cd build/install/codyze
 $ ./bin/codyze -c -m ./mark -s <sourcepath>
 ```
-where `<sourcepath>` denotes the path to the source directory or file.
+where `<sourcepath>` denotes the path to the source directory or file which should be analyzed.
 
 Codyze can be further configured with more command line arguments or a YAML configuration file.
 For more information about the usage and configurations, please refer to https://www.codyze.io and the corresponding [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Codyze is a static code analyzer that focuses on verifying security compliance i
 
 Documentation: https://www.codyze.io
 
-## Build & run Codyze
+## Build & Run Codyze
 
 Java 11 (OpenJDK) is a prerequisite.
 
@@ -22,16 +22,20 @@ To build an executable version of Codyze, use the `installDist` task:
 $ ./gradlew installDist
 ```
 
-This will provide you with an executable Codyze installation under `build/install/codyze`. Change to that directory and run Codyze:
+This will provide you with an executable Codyze installation under `build/install/codyze`.
+To start Codyze, change to the directory and run Codyze.
+
+Codyze has three execution modes, commando line interface mode, language server protocol mode and interactive console mode.
+One of these modes has to be specified as command line option when running Codyze.
+An exemplary call to start the interactive console mode would be:
 
 ```shell
 $ cd build/install/codyze
-$ ./bin/codyze
+$ ./bin/codyze -t
 ```
 
-Codyze can be configured with either command line arguments or a YAML configuration file.
-
-For further information about the configurations, please refer to the [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage) and https://www.codyze.io.
+Codyze can be further configured with more command line arguments or a YAML configuration file.
+For more information about the usage and configurations, please refer to https://www.codyze.io and the [wiki page](https://github.com/Fraunhofer-AISEC/codyze/wiki/Usage).
 
 
 ## Research & Student Work

--- a/schema/codyze-config-schema.json
+++ b/schema/codyze-config-schema.json
@@ -21,7 +21,8 @@
         },
         "sarif": {
             "description": "Enables the SARIF output",
-            "type": "boolean"
+            "type": "boolean",
+            "default": "false"
         },
         "codyze": {
             "description": "Configurations for codyze",
@@ -38,7 +39,8 @@
                 },
                 "no-good-findings": {
                     "description": "Disables output of \"positive\" findings",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": "false"
                 },
                 "disabled-mark-rules": {
                     "description": "The specified mark rules will be excluded from being parsed and processed.",

--- a/schema/codyze-config-schema.json
+++ b/schema/codyze-config-schema.json
@@ -1,0 +1,189 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Codyze Configuration File Schema",
+    "description": "A schema for writing yaml configuration files for codyze",
+    "type": "object",
+    "properties": {
+        "source": {
+            "description": "Path to the to be analyzed directory or file",
+            "type": "string"
+        },
+        "output": {
+            "description": "Path to output file in which results are written. Use “-” to print to stdout",
+            "default": "findings.sarif",
+            "type": "string"
+        },
+        "timeout": {
+            "description": "Terminates analysis after given minutes",
+            "default": "120",
+            "type": "integer",
+            "exclusiveMinimum": 0
+        },
+        "sarif": {
+            "description": "Enables the SARIF output",
+            "type": "boolean"
+        },
+        "codyze": {
+            "description": "Configurations for codyze",
+            "type": "object",
+            "properties": {
+                "mark": {
+                    "description": "Paths to Mark rule files",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true,
+                    "default": ["./"]
+                },
+                "no-good-findings": {
+                    "description": "Disables output of \"positive\" findings",
+                    "type": "boolean"
+                },
+                "disabled-mark-rules": {
+                    "description": "The specified mark rules will be excluded from being parsed and processed.",
+                    "type": "array",
+                    "items": {
+                        "description": "Has to be specified as <package.rule>.",
+                        "type": "string",
+                        "pattern": "\\.."
+                    }
+                },
+                "pedantic": {
+                    "description": "Activates pedantic analysis mode. In this mode, Codyze analyzes all MARK rules and report all findings. This option overrides \"disabledMarkRules\" and \"noGoodFinding\" and ignores any Codyze source code comments.",
+                    "type": "boolean",
+                    "default" : "false"
+                },
+                "analysis": {
+                    "description": "Analysis configurations",
+                    "type": "object",
+                    "properties": {
+                        "typestate": {
+                            "description": "Specify typestate analysis mode.\nDFA: Deterministic finite automaton (faster, intraprocedural)\nWPDS: Weighted pushdown system (slower, interprocedural)",
+                            "default": "DFA",
+                            "type": "string",
+                            "enum": [
+                                "DFA",
+                                "WPDS"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "cpg": {
+            "description": "Configurations for cpg",
+            "type": "object",
+            "properties": {
+                "additional-languages": {
+                    "description": "Specify programming languages of to be analyzed files (full names)",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "python",
+                            "go"
+                        ]
+                    },
+                    "uniqueItems": true
+                },
+                "unity": {
+                    "description": "Only relevant for C++. A unity build refers to a build that consolidates all translation units into a single one, which has the advantage that header files are only processed once, adding far less duplicate nodes to the graph",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "type-system-in-frontend" : {
+                    "description": "If false, type listener system is only activated after the frontends are done building the initial AST structure.",
+                    "type": "boolean",
+                    "default": "true"
+                },
+                "default-passes": {
+                    "description": "Controls the usage of default passes for cpg.",
+                    "type": "boolean",
+                    "default": "true"
+                },
+                "passes": {
+                    "description": "CPG passes in the order in which they should be executed, fully qualified name of the classes only. If default-passes is specified, the default passes are executed first.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": ".\\.."
+                    }
+                },
+                "debug-parser": {
+                    "description": "Controls debug output generation for the cpg parser",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "disable-cleanup": {
+                    "description": "Switch off cleaning up TypeManager memory after the analysis. Set to true only for testing",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "code-in-nodes": {
+                    "description": "Controls showing the code of a node as parameter in the node",
+                    "type": "boolean",
+                    "default": "true"
+                },
+                "annotations": {
+                    "description": "Enables processing annotations or annotation-like elements",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "fail-on-error": {
+                    "description": "Should the parser/translation fail on errors (true) or try to continue in a best-effort manner (false)",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "symbols":  {
+                    "description": "Definition of additional symbols",
+                    "type": "object",
+                    "properties": {
+                        "description": "symbol: description",
+                        "type": "string"
+                    }
+                },
+                "use-parallel-frontends": {
+                    "description": "Enables parsing the ASTs for the source files in parallel, but the passes afterwards will still run in a single thread",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                "translation": {
+                    "description": "Translation configurations",
+                    "type": "object",
+                    "properties": {
+                        "analyze-includes": {
+                            "description": "Enables parsing of include files. If includePaths are given, the parser will resolve symbols/templates from these in include but not load their parse tree",
+                            "type": "boolean",
+                            "default": "false"
+                        },
+                        "includes": {
+                            "description": "Paths containing include files",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        },
+                        "enabled-includes": {
+                            "description": "If includes is not empty, only the specified files will be parsed and processed in the cpg, unless it is a part of the disabled list, in which it will be ignored.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        },
+                        "disabled-includes": {
+                            "description": "If includes is not empty, the specified files will be excluded from being parsed and processed in the cpg. The disabled list entries always take priority over the enabled list entries.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema/codyze-config-schema.json
+++ b/schema/codyze-config-schema.json
@@ -145,7 +145,7 @@
                         "type": "string"
                     }
                 },
-                "use-parallel-frontends": {
+                "parallel-frontends": {
                     "description": "Enables parsing the ASTs for the source files in parallel, but the passes afterwards will still run in a single thread",
                     "type": "boolean",
                     "default": "false"

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -91,6 +91,7 @@ class CpgConfiguration {
     )
     var codeInNodes = true
 
+    @JsonProperty("annotations")
     @Option(
         names = ["--annotations"],
         description = ["Enables processing annotations or annotation-like elements"],
@@ -115,6 +116,7 @@ class CpgConfiguration {
     )
     var symbols: Map<String, String> = HashMap()
 
+    @JsonProperty("parallel-frontends")
     @Option(
         names = ["--parallel-frontends"],
         description =


### PR DESCRIPTION
This PR adds a JSON schema which users can use to generate and validate their YAML configuration files. The README is also updated to include a short exemplary codyze call and link to the configuration wiki page instead of listing them all in the README. 