### PR TITLE
Change config path default

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -49,7 +49,6 @@ public class Main {
 	 */
 	public static void main(String... args) throws Exception {
 		ConfigFilePath firstPass = new ConfigFilePath();
-		firstPass.configFile = null;
 		CommandLine cmd = new CommandLine(firstPass);
 		cmd.parseArgs(args); // first pass to get potential config file path
 		if (cmd.isUsageHelpRequested()) {
@@ -135,8 +134,9 @@ public class Main {
 	// Stores path to config file given as cli option
 	@Command(mixinStandardHelpOptions = true)
 	public static class ConfigFilePath {
-		@Option(names = { "--config" }, paramLabel = "<path>", description = "Parse configuration settings from this file.\n\t(Default: ${DEFAULT-VALUE})")
-		public File configFile = new File("codyze.yaml");
+		@Option(names = {
+				"--config" }, paramLabel = "<path>", fallbackValue = "codyze.yaml", arity = "0..1", description = "Parse configuration settings from this file. If no file path is specified, codyze will try to load the configuration file from ./codyze.yaml")
+		public File configFile;
 
 		@Unmatched
 		List<String> remainder;

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
-import de.fraunhofer.aisec.codyze.Main.ConfigFilePath
 import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
 import de.fraunhofer.aisec.codyze.config.converters.FileDeserializer
 import de.fraunhofer.aisec.codyze.config.converters.OutputDeserializer
@@ -244,12 +243,7 @@ class Configuration {
                 if (configFile != null) {
                     parseFile(configFile)
                 } else {
-                    val defaultConfigFile = ConfigFilePath().configFile
-                    if (defaultConfigFile.isFile) {
-                        parseFile(defaultConfigFile)
-                    } else {
-                        Configuration()
-                    }
+                    Configuration()
                 }
             config.parseCLI(*args)
             return config


### PR DESCRIPTION
This PR changes the config path default behavior so that the default value "codyze.yaml" is only used when --config is specified. When the option is not present, no config file is parsed.