### PR TITLE
lighter weight logging

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/AnalysisServer.java
@@ -88,7 +88,7 @@ public class AnalysisServer {
 
 		int i = 0;
 		for (Class<? extends Builtin> builtin : reflections.getSubTypesOf(Builtin.class)) {
-			log.info("Registering builtin {}", builtin.getName());
+			log.debug("Registering builtin {}", builtin.getName());
 			try {
 				Builtin bi = builtin.getDeclaredConstructor().newInstance();
 				BuiltinRegistry.getInstance().register(bi);
@@ -295,7 +295,7 @@ public class AnalysisServer {
 				try {
 					getMarkFileLocations(markFile, allMarkFiles);
 					for (File f : allMarkFiles) {
-						log.info("  Loading MARK file {}", f.getAbsolutePath());
+						log.debug("  Loading MARK file {}", f.getAbsolutePath());
 						parser.addMarkFile(f);
 					}
 				}

--- a/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/Evaluator.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/analysis/markevaluation/Evaluator.java
@@ -109,7 +109,7 @@ public class Evaluator {
 		// iterate over all entities and precalculate:
 		// - call statements to vertices
 		for (var ent : markModel.getEntities()) {
-			log.info("Precalculating call statements for entity {}", ent.getName());
+			log.debug("Precalculating call statements for entity {}", ent.getName());
 			ent.parseVars();
 
 			for (var op : ent.getOps()) {
@@ -145,7 +145,7 @@ public class Evaluator {
 	 */
 	private void evaluateRules(AnalysisContext ctx, @NonNull Graph graph) {
 		for (MRule rule : this.markModel.getRules()) {
-			log.info("checking rule {}", rule.getName());
+			log.debug("checking rule {}", rule.getName());
 
 			// Evaluate "using" part and collect the instances of MARK entities, as well as
 			// the potential vertex representing the base object variables.


### PR DESCRIPTION
This PR aims to reduce the number of lines produced by logging on the INFO level .
For this reason some (debug) logging statements that are called repeatedly in many individual instances are shifted to DEBUG level.
In all those cases there is still either a concluding logging statement on INFO level or associated WARN level statements.

This small change eliminates 302 out of 422 lines of logging from INFO level in the simple case of checking [this file](https://github.com/Fraunhofer-AISEC/codyze/blob/main/src/test/resources/botan_rule_tr_test/2_1_2_1_02.cpp) with 70 different Mark rules.