### PR TITLE
Make collection type options appendable

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -140,7 +140,7 @@ public class Main {
 	@Command(mixinStandardHelpOptions = true)
 	public static class ConfigFilePath {
 		@Option(names = {
-				"--config" }, paramLabel = "<path>", fallbackValue = "codyze.yaml", arity = "0..1", description = "Parse configuration settings from this file. If no file path is specified, codyze will try to load the configuration file from codyze.yaml")
+				"--config" }, paramLabel = "<path>", fallbackValue = "codyze.yaml", arity = "0..1", description = "Parse configuration settings from this file. If no file path is specified, codyze will try to load the configuration file from ${FALLBACK-VALUE}")
 		public File configFile;
 
 		@Unmatched

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -195,7 +195,6 @@ public class Main {
 				sb.append(help.colorScheme().text(argGroupSpec.heading()).toString());
 			}
 
-
 			// render all options that are not in subgroups
 			sb.append(help.optionListExcludingGroups(
 				argGroupSpec.options().stream().filter(optionSpec -> optionSpec.group().equals(argGroupSpec)).collect(Collectors.toList())));

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -150,10 +150,10 @@ public class Main {
 		private ConfigFilePath configFilePath;
 
 		// ArgGroups only for display purposes
-		@ArgGroup(heading = "@|bold,underline Codyze Options|@\n", exclusive = false)
+		@ArgGroup(heading = "@|bold,underline Codyze Options|@\n", exclusive = false, validate = true)
 		private CodyzeConfiguration codyzeConfig = new CodyzeConfiguration();
 
-		@ArgGroup(heading = "", exclusive = false)
+		@ArgGroup(exclusive = false)
 		private Configuration configuration = new Configuration();
 
 		@ArgGroup(exclusive = false, heading = "Analysis Options\n")
@@ -181,7 +181,7 @@ public class Main {
 			for (CommandSpec c : mix.values()) {
 				sb.append(help.optionListExcludingGroups(c.options().stream().filter(optionSpec -> optionSpec.group() == null).collect(Collectors.toList())));
 			}
-			sb.append("\n");
+
 			for (ArgGroupSpec group : spec.argGroups()) {
 				addHierachy(group, sb);
 			}
@@ -190,13 +190,16 @@ public class Main {
 		}
 
 		private void addHierachy(ArgGroupSpec argGroupSpec, StringBuilder sb) {
-			sb.append(help.colorScheme().text(argGroupSpec.heading()).toString());
+			if (argGroupSpec.heading() != null) {
+				sb.append("\n");
+				sb.append(help.colorScheme().text(argGroupSpec.heading()).toString());
+			}
+
 
 			// render all options that are not in subgroups
 			sb.append(help.optionListExcludingGroups(
 				argGroupSpec.options().stream().filter(optionSpec -> optionSpec.group().equals(argGroupSpec)).collect(Collectors.toList())));
 
-			sb.append("\n");
 			for (ArgGroupSpec group : argGroupSpec.subgroups()) {
 				addHierachy(group, sb);
 			}

--- a/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -54,7 +54,11 @@ public class Main {
 		cmd.parseArgs(args); // first pass to get potential config file path
 		if (cmd.isUsageHelpRequested()) {
 			// print help message
-			CommandLine c = new CommandLine(new Help());
+			Help help = new Help();
+			System.setProperty("source", Arrays.toString(help.configuration.getSource()));
+			System.setProperty("mark", Arrays.toString(help.codyzeConfig.getMark()));
+
+			CommandLine c = new CommandLine(help);
 			c.getHelpSectionMap().put(SECTION_KEY_OPTION_LIST, new HelpRenderer());
 			c.usage(System.out);
 			System.exit(c.getCommandSpec().exitCodeOnUsageHelp());

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -78,7 +78,7 @@ class MarkArgGroup {
     }
 
     @Option(
-        names = ["-m+", "--mark+"],
+        names = ["--mark+"],
         paramLabel = "<path>",
         description =
             ["See --mark, but appends the values to the ones specified in configuration file."],

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -1,8 +1,10 @@
 package de.fraunhofer.aisec.codyze.config
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import de.fraunhofer.aisec.codyze.analysis.TypestateMode
 import java.io.File
+import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Option
 
 class CodyzeConfiguration {
@@ -10,12 +12,7 @@ class CodyzeConfiguration {
     // TODO: names
     val analysis = AnalysisMode()
 
-    @Option(
-        names = ["-m", "--mark"],
-        paramLabel = "<path>",
-        description = ["Loads MARK policy files.\n\t(Default: \${DEFAULT-VALUE})"],
-        split = ","
-    )
+    @JsonIgnore @ArgGroup(exclusive = true) val markCLI = MarkArgGroup()
     var mark: Array<File> = arrayOf(File("./"))
 
     // TODO: change name or make into warning levels
@@ -29,14 +26,7 @@ class CodyzeConfiguration {
     )
     var noGoodFindings = false
 
-    @Option(
-        names = ["--disabled-mark-rules"],
-        paramLabel = "<package.rule>",
-        description =
-            [
-                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). If there is no package name, specify rule as \".rule\". Use \'*\' to disable an entire package."],
-        split = ","
-    )
+    @JsonIgnore @ArgGroup(exclusive = true) val disabledMarkRulesCLI = DisabledMarkArgGroup()
     var disabledMarkRules: List<String> = emptyList()
 
     @Option(
@@ -68,4 +58,55 @@ class AnalysisMode {
                     "\t(Default: \${DEFAULT-VALUE})"]
     )
     var tsMode = TypestateMode.DFA
+}
+
+class MarkArgGroup {
+    var append = false
+
+    @Option(
+        names = ["-m", "--mark"],
+        paramLabel = "<path>",
+        description = ["Loads MARK policy files.\n\t(Default: \${DEFAULT-VALUE})"],
+        split = ","
+    )
+    var mark: Array<File> = arrayOf(File("./"))
+
+    @Option(
+        names = ["-m+", "--mark+"],
+        paramLabel = "<path>",
+        description =
+            ["See --mark, but appends the values to the ones specified in configuration file."],
+        split = ","
+    )
+    fun append(value: Array<File>) {
+        append = true
+        this.mark = value
+    }
+}
+
+class DisabledMarkArgGroup {
+    var append = false
+
+    @Option(
+        names = ["--disabled-mark-rules"],
+        paramLabel = "<package.rule>",
+        description =
+            [
+                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). If there is no package name, specify rule as \".rule\". Use \'*\' to disable an entire package."],
+        split = ","
+    )
+    var disabledMarkRules: List<String> = emptyList()
+
+    @Option(
+        names = ["--disabled-mark-rules+"],
+        paramLabel = "<package.rule>",
+        description =
+            [
+                "See --disabled-mark-rules, but appends the values to the ones specified in configuration file."],
+        split = ","
+    )
+    fun append(value: List<String>) {
+        append = true
+        this.disabledMarkRules = value
+    }
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -62,6 +62,9 @@ class AnalysisMode {
 
 class MarkArgGroup {
     var append = false
+    var matched = false
+
+    var mark: Array<File> = arrayOf(File("./"))
 
     @Option(
         names = ["-m", "--mark"],
@@ -69,7 +72,10 @@ class MarkArgGroup {
         description = ["Loads MARK policy files.\n\t(Default: \${DEFAULT-VALUE})"],
         split = ","
     )
-    var mark: Array<File> = arrayOf(File("./"))
+    fun match(value: Array<File>) {
+        matched = true
+        this.mark = value
+    }
 
     @Option(
         names = ["-m+", "--mark+"],
@@ -80,13 +86,15 @@ class MarkArgGroup {
     )
     fun append(value: Array<File>) {
         append = true
-        this.mark = value
+        match(value)
     }
 }
 
 class DisabledMarkArgGroup {
     var append = false
+    var matched = false
 
+    var disabledMarkRules: List<String> = emptyList()
     @Option(
         names = ["--disabled-mark-rules"],
         paramLabel = "<package.rule>",
@@ -95,7 +103,10 @@ class DisabledMarkArgGroup {
                 "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). If there is no package name, specify rule as \".rule\". Use \'*\' to disable an entire package."],
         split = ","
     )
-    var disabledMarkRules: List<String> = emptyList()
+    fun match(value: List<String>) {
+        matched = true
+        this.disabledMarkRules = value
+    }
 
     @Option(
         names = ["--disabled-mark-rules+"],
@@ -107,6 +118,6 @@ class DisabledMarkArgGroup {
     )
     fun append(value: List<String>) {
         append = true
-        this.disabledMarkRules = value
+        match(value)
     }
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -64,7 +64,7 @@ class MarkArgGroup {
     var append = false
     var matched = false
 
-    var mark: Array<File> = arrayOf(File("./"))
+    var mark: Array<File> = emptyArray()
 
     @Option(
         names = ["-m", "--mark"],

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -69,7 +69,7 @@ class MarkArgGroup {
     @Option(
         names = ["-m", "--mark"],
         paramLabel = "<path>",
-        description = ["Loads MARK policy files.\n\t(Default: \${DEFAULT-VALUE})"],
+        description = ["Loads MARK policy files.\n\t(Default: \${sys:mark})"],
         split = "\${sys:path.separator}"
     )
     fun match(value: Array<File>) {

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -130,7 +130,8 @@ class Configuration {
 
         val disabledRulesMap = mutableMapOf<String, DisabledMarkRulesValue>()
         val disabledMarkRules = codyze.disabledMarkRulesCLI.disabledMarkRules.toMutableList()
-        if (!codyze.disabledMarkRulesCLI.matched || codyze.disabledMarkRulesCLI.append) disabledMarkRules.addAll(codyze.disabledMarkRules)
+        if (!codyze.disabledMarkRulesCLI.matched || codyze.disabledMarkRulesCLI.append)
+            disabledMarkRules.addAll(codyze.disabledMarkRules)
 
         for (mName in disabledMarkRules) {
             val index = mName.lastIndexOf('.')
@@ -510,7 +511,7 @@ class SourceArgGroup {
         names = ["-s", "--source"],
         paramLabel = "<path>",
         split = "\${sys:path.separator}",
-        description = ["Source files or folders to analyze.\n\t(Default: \${DEFAULT-VALUE})"]
+        description = ["Source files or folders to analyze.\n\t(Default: \${sys:source})"]
     )
     fun match(value: Array<File>) {
         matched = true

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -130,7 +130,7 @@ class Configuration {
 
         val disabledRulesMap = mutableMapOf<String, DisabledMarkRulesValue>()
         val disabledMarkRules = codyze.disabledMarkRulesCLI.disabledMarkRules.toMutableList()
-        if (codyze.disabledMarkRulesCLI.append) disabledMarkRules.addAll(codyze.disabledMarkRules)
+        if (!codyze.disabledMarkRulesCLI.matched || codyze.disabledMarkRulesCLI.append) disabledMarkRules.addAll(codyze.disabledMarkRules)
 
         for (mName in disabledMarkRules) {
             val index = mName.lastIndexOf('.')

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -93,10 +93,10 @@ class Configuration {
                 .disableGoodFindings(codyze.noGoodFindings)
                 .pedantic(codyze.pedantic)
 
-        if (!codyze.markCLI.matched || codyze.markCLI.append)
-            config.markFiles(*codyze.mark.map { m -> m.absolutePath }.toTypedArray())
-        if (codyze.markCLI.matched)
-            config.markFiles(*codyze.markCLI.mark.map { m -> m.absolutePath }.toTypedArray())
+        val mark = mutableListOf<File>()
+        if (!codyze.markCLI.matched || codyze.markCLI.append) mark.addAll(codyze.mark)
+        if (codyze.markCLI.matched) mark.addAll(codyze.markCLI.mark)
+        config.markFiles(*mark.map { m -> m.absolutePath }.toTypedArray())
 
         val disabledRulesMap = mutableMapOf<String, DisabledMarkRulesValue>()
         val disabledMarkRules = codyze.disabledMarkRulesCLI.disabledMarkRules.toMutableList()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -138,6 +138,8 @@ class TranslationSettings {
 
 class PassesArgGroup {
     var append = false
+    var matched = false
+
     var passes: List<Pass> = emptyList()
 
     @Option(
@@ -148,8 +150,8 @@ class PassesArgGroup {
                 "CPG passes in the order in which they should be executed, fully qualified name of the classes only. If default-passes is specified, the default passes are executed first."],
         split = ","
     )
-    @JvmName("setPassesNull")
-    fun setPasses(passes: List<Pass?>) {
+    fun match(passes: List<Pass?>) {
+        matched = true
         this.passes = passes.filterNotNull()
     }
 
@@ -162,12 +164,15 @@ class PassesArgGroup {
     )
     fun append(value: List<Pass?>) {
         append = true
-        setPasses(value)
+        match(value)
     }
 }
 
 class SymbolsArgGroup {
     var append = false
+    var matched = false
+
+    var symbols: Map<String, String> = emptyMap()
 
     @Option(
         names = ["--symbols"],
@@ -175,7 +180,10 @@ class SymbolsArgGroup {
         description = ["Definition of additional symbols"],
         split = ","
     )
-    var symbols: Map<String, String> = emptyMap()
+    fun match(value: Map<String, String>) {
+        matched = true
+        this.symbols = value
+    }
 
     @Option(
         names = ["--symbols+"],
@@ -186,12 +194,15 @@ class SymbolsArgGroup {
     )
     fun append(value: Map<String, String>) {
         append = true
-        this.symbols = value
+        match(value)
     }
 }
 
 class IncludesArgGroup {
     var append = false
+    var matched = false
+
+    var includes: Array<File> = emptyArray()
 
     @Option(
         names = ["--includes"],
@@ -200,7 +211,10 @@ class IncludesArgGroup {
                 "Path(s) containing include files. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
         split = ":|;"
     )
-    var includes: Array<File> = emptyArray()
+    fun match(value: Array<File>) {
+        matched = true
+        this.includes = value
+    }
 
     @Option(
         names = ["--includes+"],
@@ -211,12 +225,15 @@ class IncludesArgGroup {
     )
     fun append(value: Array<File>) {
         append = true
-        this.includes = value
+        match(value)
     }
 }
 
 class EnabledIncludesArgGroup {
     var append = false
+    var matched = false
+
+    var enabledIncludes: Array<File> = emptyArray()
 
     @Option(
         names = ["--enabled-includes"],
@@ -226,7 +243,10 @@ class EnabledIncludesArgGroup {
                 "If includes is not empty, only the specified files will be parsed and processed in the cpg, unless it is a part of the disabled list, in which it will be ignored. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)"],
         split = ":|;"
     )
-    var enabledIncludes: Array<File> = emptyArray()
+    fun match(value: Array<File>) {
+        matched = true
+        this.enabledIncludes = value
+    }
 
     @Option(
         names = ["--enabled-includes+"],
@@ -238,12 +258,15 @@ class EnabledIncludesArgGroup {
     )
     fun append(value: Array<File>) {
         append = true
-        this.enabledIncludes = value
+        match(value)
     }
 }
 
 class DisabledIncludesArgGroup {
     var append = false
+    var matched = false
+
+    var disabledIncludes: Array<File> = emptyArray()
 
     @Option(
         names = ["--disabled-includes"],
@@ -253,7 +276,10 @@ class DisabledIncludesArgGroup {
                 "If includes is not empty, the specified files will be excluded from being parsed and processed in the cpg. The disabled list entries always take priority over the enabled list entries. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)"],
         split = ":|;"
     )
-    var disabledIncludes: Array<File> = emptyArray()
+    fun match(value: Array<File>) {
+        matched = true
+        this.disabledIncludes = value
+    }
 
     @Option(
         names = ["--disabled-includes+"],
@@ -265,6 +291,6 @@ class DisabledIncludesArgGroup {
     )
     fun append(value: Array<File>) {
         append = true
-        this.disabledIncludes = value
+        match(value)
     }
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -1,5 +1,6 @@
 package de.fraunhofer.aisec.codyze.config
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import de.fraunhofer.aisec.codyze.config.converters.LanguageDeserializer
@@ -7,6 +8,7 @@ import de.fraunhofer.aisec.codyze.config.converters.PassListDeserializer
 import de.fraunhofer.aisec.cpg.passes.Pass
 import java.io.File
 import java.util.*
+import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Option
 
 /** This class consists of configuration settings for CPG. */
@@ -43,29 +45,6 @@ class CpgConfiguration {
         fallbackValue = "true"
     )
     var typeSystemInFrontend = true
-
-    @Option(
-        names = ["--default-passes"],
-        negatable = true,
-        description = ["Controls the usage of default passes for cpg.\n\t(Default: true)"],
-        fallbackValue = "true"
-    )
-    // Set to null to differentiate if it was set or not
-    var defaultPasses: Boolean? = null
-
-    @Option(
-        names = ["--passes"],
-        paramLabel = "pass",
-        description =
-            [
-                "CPG passes in the order in which they should be executed, fully qualified name of the classes only. If default-passes is specified, the default passes are executed first."],
-        split = ","
-    )
-    @JvmName("setPassesNull")
-    fun setPasses(passes: List<Pass?>) {
-        this.passes = passes.filterNotNull()
-    }
-    @JsonDeserialize(using = PassListDeserializer::class) var passes: List<Pass> = ArrayList()
 
     @Option(
         names = ["--debug-parser"],
@@ -110,12 +89,7 @@ class CpgConfiguration {
     )
     var failOnError = false
 
-    @Option(
-        names = ["--symbols"],
-        paramLabel = "<symbol=definition>",
-        description = ["Definition of additional symbols"],
-        split = ","
-    )
+    @JsonIgnore @ArgGroup(exclusive = true) val symbolsCLI = SymbolsArgGroup()
     var symbols: Map<String, String> = HashMap()
 
     @JsonProperty("parallel-frontends")
@@ -127,6 +101,18 @@ class CpgConfiguration {
         fallbackValue = "true"
     )
     var useParallelFrontends = false
+
+    @Option(
+            names = ["--default-passes"],
+            negatable = true,
+            description = ["Controls the usage of default passes for cpg.\n\t(Default: true)"],
+            fallbackValue = "true"
+    )
+    // Set to null to differentiate if it was set or not
+    var defaultPasses: Boolean? = null
+
+    @JsonIgnore @ArgGroup(exclusive = true) val passesCLI = PassesArgGroup()
+    @JsonDeserialize(using = PassListDeserializer::class) var passes: List<Pass> = ArrayList()
 }
 
 /** This class consists of settings that control how CPG will process includes. */
@@ -140,6 +126,73 @@ class TranslationSettings {
     )
     var analyzeIncludes = false
 
+    @JsonIgnore @ArgGroup(exclusive = true) val includesCLI = IncludesArgGroup()
+    var includes: Array<File> = emptyArray()
+
+    @JsonIgnore @ArgGroup(exclusive = true) val enabledIncludesCLI = EnabledIncludesArgGroup()
+    var enabledIncludes: Array<File> = emptyArray()
+
+    @JsonIgnore @ArgGroup(exclusive = true) val disabledIncludesCLI = DisabledIncludesArgGroup()
+    var disabledIncludes: Array<File> = emptyArray()
+}
+
+class PassesArgGroup {
+    var append = false
+    var passes: List<Pass> = emptyList()
+
+    @Option(
+        names = ["--passes"],
+        paramLabel = "pass",
+        description =
+            [
+                "CPG passes in the order in which they should be executed, fully qualified name of the classes only. If default-passes is specified, the default passes are executed first."],
+        split = ","
+    )
+    @JvmName("setPassesNull")
+    fun setPasses(passes: List<Pass?>) {
+        this.passes = passes.filterNotNull()
+    }
+
+    @Option(
+        names = ["--passes+"],
+        paramLabel = "<pass>",
+        description =
+            ["See passes, but appends the values to the ones specified in configuration file."],
+        split = ","
+    )
+    fun append(value: List<Pass?>) {
+        append = true
+        setPasses(value)
+    }
+}
+
+class SymbolsArgGroup {
+    var append = false
+
+    @Option(
+        names = ["--symbols"],
+        paramLabel = "<symbol=definition>",
+        description = ["Definition of additional symbols"],
+        split = ","
+    )
+    var symbols: Map<String, String> = emptyMap()
+
+    @Option(
+        names = ["--symbols+"],
+        paramLabel = "<symbol=definition>",
+        description =
+            ["See --symbols, but appends the values to the ones specified in configuration file."],
+        split = ","
+    )
+    fun append(value: Map<String, String>) {
+        append = true
+        this.symbols = value
+    }
+}
+
+class IncludesArgGroup {
+    var append = false
+
     @Option(
         names = ["--includes"],
         description =
@@ -148,6 +201,22 @@ class TranslationSettings {
         split = ":|;"
     )
     var includes: Array<File> = emptyArray()
+
+    @Option(
+        names = ["--includes+"],
+        paramLabel = "<includes>",
+        description =
+            ["See --includes, but appends the values to the ones specified in configuration file."],
+        split = ":|;"
+    )
+    fun append(value: Array<File>) {
+        append = true
+        this.includes = value
+    }
+}
+
+class EnabledIncludesArgGroup {
+    var append = false
 
     @Option(
         names = ["--enabled-includes"],
@@ -160,6 +229,23 @@ class TranslationSettings {
     var enabledIncludes: Array<File> = emptyArray()
 
     @Option(
+        names = ["--enabled-includes+"],
+        paramLabel = "<path>",
+        description =
+            [
+                "See --enabled-includes, but appends the values to the ones specified in configuration file."],
+        split = ":|;"
+    )
+    fun append(value: Array<File>) {
+        append = true
+        this.enabledIncludes = value
+    }
+}
+
+class DisabledIncludesArgGroup {
+    var append = false
+
+    @Option(
         names = ["--disabled-includes"],
         paramLabel = "<path>",
         description =
@@ -168,4 +254,17 @@ class TranslationSettings {
         split = ":|;"
     )
     var disabledIncludes: Array<File> = emptyArray()
+
+    @Option(
+        names = ["--disabled-includes+"],
+        paramLabel = "<path>",
+        description =
+            [
+                "See --disabled-includes, but appends the values to the ones specified in configuration file."],
+        split = ":|;"
+    )
+    fun append(value: Array<File>) {
+        append = true
+        this.disabledIncludes = value
+    }
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -103,10 +103,10 @@ class CpgConfiguration {
     var useParallelFrontends = false
 
     @Option(
-            names = ["--default-passes"],
-            negatable = true,
-            description = ["Controls the usage of default passes for cpg.\n\t(Default: true)"],
-            fallbackValue = "true"
+        names = ["--default-passes"],
+        negatable = true,
+        description = ["Controls the usage of default passes for cpg.\n\t(Default: true)"],
+        fallbackValue = "true"
     )
     // Set to null to differentiate if it was set or not
     var defaultPasses: Boolean? = null

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
@@ -150,7 +150,7 @@ class ConfigCLILoadTest {
     @Test
     @Throws(Exception::class)
     fun appendTest() {
-        val options = arrayOf("-m+=mark5,mark7,mark6", "--includes+=include7;include193;include3")
+        val options = arrayOf("-mark+=mark5,mark7,mark6", "--includes+=include7;include193;include3")
         val config = Configuration.initConfig(correctFile, *options)
         val serverConfig = config.buildServerConfiguration()
         val translationConfig = config.buildTranslationConfiguration()

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
@@ -150,7 +150,8 @@ class ConfigCLILoadTest {
     @Test
     @Throws(Exception::class)
     fun appendTest() {
-        val options = arrayOf("-mark+=mark5,mark7,mark6", "--includes+=include7;include193;include3")
+        val options =
+            arrayOf("--mark+=mark5,mark7,mark6", "--includes+=include7;include193;include3")
         val config = Configuration.initConfig(correctFile, *options)
         val serverConfig = config.buildServerConfiguration()
         val translationConfig = config.buildTranslationConfiguration()

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
@@ -151,7 +151,10 @@ class ConfigCLILoadTest {
     @Throws(Exception::class)
     fun appendTest() {
         val options =
-            arrayOf("--mark+=mark5,mark7,mark6", "--includes+=include7;include193;include3")
+            arrayOf(
+                "--mark+=mark5${File.pathSeparator}mark7${File.pathSeparator}mark6",
+                "--includes+=include7${File.pathSeparator}include193${File.pathSeparator}include3"
+            )
         val config = Configuration.initConfig(correctFile, *options)
         val serverConfig = config.buildServerConfiguration()
         val translationConfig = config.buildTranslationConfiguration()
@@ -189,12 +192,12 @@ class ConfigCLILoadTest {
             Configuration.initConfig(
                 additionalOptionFile,
                 "-c",
-                "--passes+=de.fraunhofer.aisec.cpg.passes.FilenameMapper," +
+                "--passes+=de.fraunhofer.aisec.cpg.passes.FilenameMapper${File.pathSeparator}" +
                     "de.fraunhofer.aisec.cpg.passes.CallResolver",
-                "--symbols+=&=and,+=plus",
+                "--symbols+=&=and${File.pathSeparator}+=plus",
                 "--default-passes",
-                "--includes+=include9;include193;include13",
-                "--enabled-includes+=include9;include52",
+                "--includes+=include9${File.pathSeparator}include193${File.pathSeparator}include13",
+                "--enabled-includes+=include9${File.pathSeparator}include52",
                 "--disabled-includes+=include13"
             )
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
@@ -288,7 +291,7 @@ class ConfigCLILoadTest {
         val config =
             Configuration.initConfig(
                 disabledMarkFile,
-                "--disabled-mark-rules+=package.mark0,package2.*"
+                "--disabled-mark-rules+=package.mark0${File.pathSeparator}package2.*"
             )
         val serverConfiguration = config.buildServerConfiguration()
         val expectedMap =

--- a/src/test/resources/config-files/disabled_mark.yml
+++ b/src/test/resources/config-files/disabled_mark.yml
@@ -1,0 +1,5 @@
+codyze:
+  disabled-mark-rules:
+    - package.mark1
+    - .mark2
+    - package0.mark123


### PR DESCRIPTION
This PR add a new option name (e.g. --option-name+) for all list and map type options so that the data from the command line can  be appended to the config file data instead of overwriting it.