### PR TITLE
Fix typos and inconsistencies in help message

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -23,7 +23,7 @@ class CodyzeConfiguration {
         names = ["--no-good-findings"],
         description =
             [
-                "Disable output of \"positive\" findings which indicate correct implementations\n" +
+                "Disable output of \"positive\" findings which indicate correct implementations.\n" +
                     "\t(Default: \${DEFAULT-VALUE})"],
         fallbackValue = "true"
     )

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -31,10 +31,10 @@ class CodyzeConfiguration {
 
     @Option(
         names = ["--disabled-mark-rules"],
-        paramLabel = "<package.rule>",
+        paramLabel = "<package>.<rule>",
         description =
             [
-                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name (package.rule). If there is no package name, specify rule as \".rule\". Use \'*\' to disable an entire package."],
+                "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name. If there is no package name, specify rule as \".<rule>\". Use \'<package>.*\' to disable an entire package."],
         split = ","
     )
     var disabledMarkRules: List<String> = emptyList()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CodyzeConfiguration.kt
@@ -14,7 +14,7 @@ class CodyzeConfiguration {
         names = ["-m", "--mark"],
         paramLabel = "<path>",
         description = ["Loads MARK policy files.\n\t(Default: \${DEFAULT-VALUE})"],
-        split = ","
+        split = "\${sys:path.separator}"
     )
     var mark: Array<File> = arrayOf(File("./"))
 
@@ -35,7 +35,7 @@ class CodyzeConfiguration {
         description =
             [
                 "The specified mark rules will be excluded from being parsed and processed. The rule has to be specified by its fully qualified name. If there is no package name, specify rule as \".<rule>\". Use \'<package>.*\' to disable an entire package."],
-        split = ","
+        split = "\${sys:path.separator}"
     )
     var disabledMarkRules: List<String> = emptyList()
 

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -39,7 +39,7 @@ class CpgConfiguration {
         negatable = true,
         description =
             [
-                "If false, type listener system is only activated after the frontends are done building the initial AST structure.(Default: \${DEFAULT-VALUE})"],
+                "If false, type listener system is only activated after the frontends are done building the initial AST structure.\n\t(Default: \${DEFAULT-VALUE})"],
         fallbackValue = "true"
     )
     var typeSystemInFrontend = true
@@ -69,7 +69,7 @@ class CpgConfiguration {
 
     @Option(
         names = ["--debug-parser"],
-        description = ["Controls debug output generation for the cpg parser"],
+        description = ["Controls debug output generation for the cpg parser."],
         fallbackValue = "true"
     )
     var debugParser = false
@@ -78,7 +78,7 @@ class CpgConfiguration {
         names = ["--disable-cleanup"],
         description =
             [
-                "Switch off cleaning up TypeManager memory after the analysis. Set to true only for testing"],
+                "Switch off cleaning up TypeManager memory after the analysis. Set to true only for testing."],
         fallbackValue = "true"
     )
     var disableCleanup = false
@@ -88,7 +88,7 @@ class CpgConfiguration {
         negatable = true,
         description =
             [
-                "Controls showing the code of a node as parameter in the node\n\t(Default: \${DEFAULT-VALUE})"],
+                "Controls showing the code of a node as parameter in the node.\n\t(Default: \${DEFAULT-VALUE})"],
         fallbackValue = "true"
     )
     var codeInNodes = true
@@ -96,7 +96,7 @@ class CpgConfiguration {
     @JsonProperty("annotations")
     @Option(
         names = ["--annotations"],
-        description = ["Enables processing annotations or annotation-like elements"],
+        description = ["Enables processing annotations or annotation-like elements."],
         fallbackValue = "true"
     )
     var processAnnotations = false
@@ -105,7 +105,7 @@ class CpgConfiguration {
         names = ["--fail-on-error"],
         description =
             [
-                "Should the parser/translation fail on errors (true) or try to continue in a best-effort manner (false)\n\t(Default: \${DEFAULT-VALUE})"],
+                "Should the parser/translation fail on errors (true) or try to continue in a best-effort manner (false).\n\t(Default: \${DEFAULT-VALUE})"],
         fallbackValue = "true"
     )
     var failOnError = false
@@ -113,7 +113,7 @@ class CpgConfiguration {
     @Option(
         names = ["--symbols"],
         paramLabel = "<symbol>=<definition>",
-        description = ["Definition of additional symbols"],
+        description = ["Definition of additional symbols."],
         split = ","
     )
     var symbols: Map<String, String> = HashMap()
@@ -123,7 +123,7 @@ class CpgConfiguration {
         names = ["--parallel-frontends"],
         description =
             [
-                "Enables parsing the ASTs for the source files in parallel, but the passes afterwards will still run in a single thread"],
+                "Enables parsing the ASTs for the source files in parallel, but the passes afterwards will still run in a single thread."],
         fallbackValue = "true"
     )
     var useParallelFrontends = false
@@ -145,7 +145,7 @@ class TranslationSettings {
         paramLabel = "<path>",
         description =
             [
-                "Path(s) containing include files. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
+                "Path(s) containing include files. Paths must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
         split = ":|;"
     )
     var includes: Array<File> = emptyArray()
@@ -155,7 +155,7 @@ class TranslationSettings {
         paramLabel = "<path>",
         description =
             [
-                "If includes is not empty, only the specified files will be parsed and processed in the cpg, unless it is a part of the disabled list, in which it will be ignored. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)"],
+                "If includes is not empty, only the specified files will be parsed and processed in the cpg, unless it is a part of the disabled list, in which it will be ignored. Paths must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
         split = ":|;"
     )
     var enabledIncludes: Array<File> = emptyArray()
@@ -165,7 +165,7 @@ class TranslationSettings {
         paramLabel = "<path>",
         description =
             [
-                "If includes is not empty, the specified files will be excluded from being parsed and processed in the cpg. The disabled list entries always take priority over the enabled list entries. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)"],
+                "If includes is not empty, the specified files will be excluded from being parsed and processed in the cpg. The disabled list entries always take priority over the enabled list entries. Paths must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
         split = ":|;"
     )
     var disabledIncludes: Array<File> = emptyArray()

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -112,7 +112,7 @@ class CpgConfiguration {
 
     @Option(
         names = ["--symbols"],
-        paramLabel = "<symbol=definition>",
+        paramLabel = "<symbol>=<definition>",
         description = ["Definition of additional symbols"],
         split = ","
     )

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -16,7 +16,7 @@ class CpgConfiguration {
 
     @Option(
         names = ["--additional-languages"],
-        split = ",",
+        split = "\${sys:path.separator}",
         paramLabel = "<language>",
         description =
             [
@@ -59,7 +59,7 @@ class CpgConfiguration {
         description =
             [
                 "CPG passes in the order in which they should be executed, fully qualified name of the classes only. If default-passes is specified, the default passes are executed first."],
-        split = ","
+        split = "\${sys:path.separator}"
     )
     @JvmName("setPassesNull")
     fun setPasses(passes: List<Pass?>) {
@@ -114,7 +114,7 @@ class CpgConfiguration {
         names = ["--symbols"],
         paramLabel = "<symbol>=<definition>",
         description = ["Definition of additional symbols."],
-        split = ","
+        split = "\${sys:path.separator}"
     )
     var symbols: Map<String, String> = HashMap()
 
@@ -143,10 +143,8 @@ class TranslationSettings {
     @Option(
         names = ["--includes"],
         paramLabel = "<path>",
-        description =
-            [
-                "Path(s) containing include files. Paths must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
-        split = ":|;"
+        description = ["Path(s) containing include files."],
+        split = "\${sys:path.separator}"
     )
     var includes: Array<File> = emptyArray()
 
@@ -155,8 +153,8 @@ class TranslationSettings {
         paramLabel = "<path>",
         description =
             [
-                "If includes is not empty, only the specified files will be parsed and processed in the cpg, unless it is a part of the disabled list, in which it will be ignored. Paths must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
-        split = ":|;"
+                "If includes is not empty, only the specified files will be parsed and processed in the cpg, unless it is a part of the disabled list, in which it will be ignored."],
+        split = "\${sys:path.separator}"
     )
     var enabledIncludes: Array<File> = emptyArray()
 
@@ -165,8 +163,8 @@ class TranslationSettings {
         paramLabel = "<path>",
         description =
             [
-                "If includes is not empty, the specified files will be excluded from being parsed and processed in the cpg. The disabled list entries always take priority over the enabled list entries. Paths must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],
-        split = ":|;"
+                "If includes is not empty, the specified files will be excluded from being parsed and processed in the cpg. The disabled list entries always take priority over the enabled list entries."],
+        split = "\${sys:path.separator}"
     )
     var disabledIncludes: Array<File> = emptyArray()
 }

--- a/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/CpgConfiguration.kt
@@ -17,7 +17,7 @@ class CpgConfiguration {
     @Option(
         names = ["--additional-languages"],
         split = ",",
-        paramLabel = "language",
+        paramLabel = "<language>",
         description =
             [
                 "Enables the experimental support for additional languages (currently \${COMPLETION-CANDIDATES}). Additional files need to be placed in certain locations. Please follow the CPG README."]
@@ -55,7 +55,7 @@ class CpgConfiguration {
 
     @Option(
         names = ["--passes"],
-        paramLabel = "pass",
+        paramLabel = "<pass>",
         description =
             [
                 "CPG passes in the order in which they should be executed, fully qualified name of the classes only. If default-passes is specified, the default passes are executed first."],
@@ -142,6 +142,7 @@ class TranslationSettings {
 
     @Option(
         names = ["--includes"],
+        paramLabel = "<path>",
         description =
             [
                 "Path(s) containing include files. Path must be separated by \':\' (Mac/Linux) or \';\' (Windows)."],

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
@@ -73,8 +73,8 @@ internal class CLILoadTest {
             Configuration.initConfig(
                 null,
                 "-c",
-                "--passes=de.fraunhofer.aisec.cpg.passes.EdgeCachePass:" +
-                    "de.fraunhofer.aisec.cpg.passes.FilenameMapper:" +
+                "--passes=de.fraunhofer.aisec.cpg.passes.EdgeCachePass${File.pathSeparator}" +
+                    "de.fraunhofer.aisec.cpg.passes.FilenameMapper${File.pathSeparator}" +
                     "de.fraunhofer.aisec.cpg.passes.CallResolver"
             )
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
@@ -101,10 +101,10 @@ internal class CLILoadTest {
             Configuration.initConfig(
                 null,
                 "-c",
-                "--passes=de.fraunhofer.aisec.cpg.passes.MyPass:" +
-                    "de.fraunhofer.aisec.cpg.passes.Pass:" +
-                    "de.fraunhofer.aisec.cpg.passes.scopes.BlockScope:" +
-                    "de.fraunhofer.aisec.cpg.passes.EdgeCachePass:" +
+                "--passes=de.fraunhofer.aisec.cpg.passes.MyPass${File.pathSeparator}" +
+                    "de.fraunhofer.aisec.cpg.passes.Pass${File.pathSeparator}" +
+                    "de.fraunhofer.aisec.cpg.passes.scopes.BlockScope${File.pathSeparator}" +
+                    "de.fraunhofer.aisec.cpg.passes.EdgeCachePass${File.pathSeparator}" +
                     "MyPass2"
             )
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
@@ -122,7 +122,8 @@ internal class CLILoadTest {
     @Test
     @Throws(Exception::class)
     fun symbolsOptionTest() {
-        val config = Configuration.initConfig(null, "-c", "--symbols=#=hash:*=star")
+        val config =
+            Configuration.initConfig(null, "-c", "--symbols=#=hash${File.pathSeparator}*=star")
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
         assertEquals(
             2,

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/CLILoadTest.kt
@@ -73,8 +73,8 @@ internal class CLILoadTest {
             Configuration.initConfig(
                 null,
                 "-c",
-                "--passes=de.fraunhofer.aisec.cpg.passes.EdgeCachePass," +
-                    "de.fraunhofer.aisec.cpg.passes.FilenameMapper," +
+                "--passes=de.fraunhofer.aisec.cpg.passes.EdgeCachePass:" +
+                    "de.fraunhofer.aisec.cpg.passes.FilenameMapper:" +
                     "de.fraunhofer.aisec.cpg.passes.CallResolver"
             )
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
@@ -101,10 +101,10 @@ internal class CLILoadTest {
             Configuration.initConfig(
                 null,
                 "-c",
-                "--passes=de.fraunhofer.aisec.cpg.passes.MyPass," +
-                    "de.fraunhofer.aisec.cpg.passes.Pass," +
-                    "de.fraunhofer.aisec.cpg.passes.scopes.BlockScope," +
-                    "de.fraunhofer.aisec.cpg.passes.EdgeCachePass," +
+                "--passes=de.fraunhofer.aisec.cpg.passes.MyPass:" +
+                    "de.fraunhofer.aisec.cpg.passes.Pass:" +
+                    "de.fraunhofer.aisec.cpg.passes.scopes.BlockScope:" +
+                    "de.fraunhofer.aisec.cpg.passes.EdgeCachePass:" +
                     "MyPass2"
             )
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
@@ -122,7 +122,7 @@ internal class CLILoadTest {
     @Test
     @Throws(Exception::class)
     fun symbolsOptionTest() {
-        val config = Configuration.initConfig(null, "-c", "--symbols=#=hash,*=star")
+        val config = Configuration.initConfig(null, "-c", "--symbols=#=hash:*=star")
         val translationConfiguration = config.buildTranslationConfiguration(File("test.java"))
         assertEquals(
             2,

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
@@ -25,7 +25,7 @@ class ConfigCLILoadTest {
                 "--sarif", // test if true stays true
                 "--unity", // test if false is set to true
                 "--analyze-includes=false", // test if false is set to false
-                "-m=mark5,mark7,mark6"
+                "-m=mark5:mark7:mark6"
             )
         val config = Configuration.initConfig(correctFile, *options)
         val serverConfig = config.buildServerConfiguration()
@@ -83,9 +83,9 @@ class ConfigCLILoadTest {
             Configuration.initConfig(
                 additionalOptionFile,
                 "-c",
-                "--passes=de.fraunhofer.aisec.cpg.passes.FilenameMapper," +
+                "--passes=de.fraunhofer.aisec.cpg.passes.FilenameMapper:" +
                     "de.fraunhofer.aisec.cpg.passes.CallResolver",
-                "--symbols=&=and,+=plus",
+                "--symbols=&=and:+=plus",
                 "--no-type-system-in-frontend",
                 "--default-passes"
             )

--- a/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/crymlin/ConfigCLILoadTest.kt
@@ -25,7 +25,7 @@ class ConfigCLILoadTest {
                 "--sarif", // test if true stays true
                 "--unity", // test if false is set to true
                 "--analyze-includes=false", // test if false is set to false
-                "-m=mark5:mark7:mark6"
+                "-m=mark5${File.pathSeparator}mark7${File.pathSeparator}mark6"
             )
         val config = Configuration.initConfig(correctFile, *options)
         val serverConfig = config.buildServerConfiguration()
@@ -83,9 +83,9 @@ class ConfigCLILoadTest {
             Configuration.initConfig(
                 additionalOptionFile,
                 "-c",
-                "--passes=de.fraunhofer.aisec.cpg.passes.FilenameMapper:" +
+                "--passes=de.fraunhofer.aisec.cpg.passes.FilenameMapper${File.pathSeparator}" +
                     "de.fraunhofer.aisec.cpg.passes.CallResolver",
-                "--symbols=&=and:+=plus",
+                "--symbols=&=and${File.pathSeparator}+=plus",
                 "--no-type-system-in-frontend",
                 "--default-passes"
             )


### PR DESCRIPTION
This PR fixes typos and missing punctuation in the help message. All split characters for list and map type options are changed to the path separation character for each OS (`:` for Linux/Mac, `;` for Windows) for consistency.