### PR TITLE
Remove unnecessary "if" in buildTranslationConfig

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
+++ b/src/main/java/de/fraunhofer/aisec/codyze/config/Configuration.kt
@@ -121,7 +121,7 @@ class Configuration {
         this.normalize()
         val translationConfig =
             TranslationConfiguration.builder()
-                .debugParser(if (executionMode.isLsp) false else cpg.debugParser)
+                .debugParser(cpg.debugParser)
                 .failOnError(cpg.failOnError)
                 .codeInNodes(cpg.codeInNodes)
                 .loadIncludes(cpg.translation.analyzeIncludes)


### PR DESCRIPTION
Remove unnecessary if for debugParser in buildTranslationConfig() because it is already covered by normalize()