### PR TITLE
fix toComparableString(String)

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/legacy/analysis/markevaluation/ExpressionHelper.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/legacy/analysis/markevaluation/ExpressionHelper.java
@@ -300,7 +300,7 @@ public class ExpressionHelper {
 			x = x.substring(1);
 		}
 		if (x.endsWith("\"")) {
-			x = x.substring(0, x.length() - 2);
+			x = x.substring(0, x.length() - 1);
 		}
 
 		// Check if it is numeric


### PR DESCRIPTION
Fix toComparableString(String) so only quotation mark is removed and not both quotation mark and the character before it