### PR TITLE
Fix Issue #306: Rename class name in MARK template

### DIFF
--- a/src/dist/mark/bouncycastle/KeyGenerator.mark
+++ b/src/dist/mark/bouncycastle/KeyGenerator.mark
@@ -27,7 +27,7 @@ entity KeyGenerator {
             random : java.security.SecureRandom
         );
         javax.crypto.KeyGenerator.init(random : java.security.SecureRandom);
-        javax.crypto.KeyGenerator.init(params : java.security.spec.AlgorithmParameterSpecs);
+        javax.crypto.KeyGenerator.init(params : java.security.spec.AlgorithmParameterSpec);
         javax.crypto.KeyGenerator.init(
             params : java.security.spec.AlgorithmParameterSpec,
             random : java.security.SecureRandom


### PR DESCRIPTION
Rename `java.security.spec.AlgorithmParameterSpecs` to `java.security.spec.AlgorithmParameterSpec`. Closes #306