### PR TITLE
Fix NPE due to uninitialized list

### DIFF
--- a/src/main/java/de/fraunhofer/aisec/codyze/legacy/Main.java
+++ b/src/main/java/de/fraunhofer/aisec/codyze/legacy/Main.java
@@ -18,10 +18,7 @@ import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_OPTION_LIST
 import java.io.*;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -144,7 +141,7 @@ public class Main {
 		public File configFile;
 
 		@Unmatched
-		List<String> remainder;
+		public List<String> remainder = Collections.emptyList();
 	}
 
 	// Combines all CLI Options from the different classes to be able to render a complete help message

--- a/src/test/java/de/fraunhofer/aisec/codyze/legacy/crymlin/ConfigCLILoadTest.kt
+++ b/src/test/java/de/fraunhofer/aisec/codyze/legacy/crymlin/ConfigCLILoadTest.kt
@@ -1,7 +1,9 @@
 package de.fraunhofer.aisec.codyze.legacy.crymlin
 
+import de.fraunhofer.aisec.codyze.legacy.Main.ConfigFilePath
 import de.fraunhofer.aisec.codyze.legacy.analysis.TypestateMode
 import de.fraunhofer.aisec.codyze.legacy.config.Configuration
+import de.fraunhofer.aisec.codyze.legacy.config.Configuration.Companion.initConfig
 import de.fraunhofer.aisec.codyze.legacy.config.DisabledMarkRulesValue
 import de.fraunhofer.aisec.cpg.TranslationConfiguration
 import de.fraunhofer.aisec.cpg.passes.CallResolver
@@ -9,11 +11,11 @@ import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
 import de.fraunhofer.aisec.cpg.passes.FilenameMapper
 import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
 import java.io.File
-import java.lang.Exception
-import kotlin.Throws
 import kotlin.test.*
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import picocli.CommandLine
 
 class ConfigCLILoadTest {
 
@@ -427,5 +429,16 @@ class ConfigCLILoadTest {
             sourceDisablingFile = File(sourceDisablingResource.file)
             assertNotNull(sourceDisablingFile)
         }
+    }
+
+    @Test
+    fun firstStep() {
+        val args = arrayOf("--config", "legacy/config-files/source_disabling.yml")
+
+        val firstPass = ConfigFilePath()
+        val cmd = CommandLine(firstPass)
+        cmd.parseArgs(*args)
+
+        assertDoesNotThrow { initConfig(firstPass.configFile, *firstPass.remainder.toTypedArray()) }
     }
 }


### PR DESCRIPTION
List with remaining CLI options isn't initialized causing a NPE when only the `--config` CLI option is provided.