### PR TITLE
[v2] Fix immutable list for unmatched CLI options

### DIFF
--- a/codyze-v2/src/main/java/de/fraunhofer/aisec/codyze/Main.java
+++ b/codyze-v2/src/main/java/de/fraunhofer/aisec/codyze/Main.java
@@ -141,7 +141,7 @@ public class Main {
 		public File configFile;
 
 		@Unmatched
-		public List<String> remainder = Collections.emptyList();
+		public List<String> remainder = new ArrayList<>();
 	}
 
 	// Combines all CLI Options from the different classes to be able to render a complete help message


### PR DESCRIPTION
Empty list from Collection is immutable. Causes exception when trying to add unmatched CLI options.