### PR TITLE
[v2] Fix path to release asset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: codyze-v2/build/distributions/codyze-${{ steps.determine_version.outputs.version }}.zip
+          asset_path: codyze-v2/build/distributions/codyze-v2-${{ steps.determine_version.outputs.version }}.zip
           asset_name: codyze-${{ steps.determine_version.outputs.version }}.zip
           asset_content_type: application/zip
       - name: "Upload Plugin Asset"


### PR DESCRIPTION
Release assets carry as prefix the name of the build.