### PR TITLE
Disable major image updates in Dockerfiles through renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
     ":disableDependencyDashboard",
     ":assignAndReview(fwendland)",
     ":enableVulnerabilityAlerts",
-    ":separateMultipleMajorReleases"
+    ":separateMultipleMajorReleases",
+    "docker:disableMajor"
   ],
   "ignoreDeps": [
     "de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark"


### PR DESCRIPTION
We rather update major version such as Java manually.