### PR TITLE
Update dependencies and fix v2 package names

### DIFF
--- a/codyze-v3/codyze-specification-languages/mark/build.gradle.kts
+++ b/codyze-v3/codyze-specification-languages/mark/build.gradle.kts
@@ -5,24 +5,25 @@ plugins {
 dependencies {
     implementation(projects.codyzeCore)
 
-    implementation(libs.cpg.analysis)
+    implementation(libs.bundles.cpg)
     implementation(libs.sarif4k)
 
     // weighted pushdown systems
-    api("de.breakpointsec:pushdown:1.1") // TODO find maintained alternative
+    //api("de.breakpointsec:pushdown:1.1") // TODO find maintained alternative
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
     //api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:bbd54a7b11:repackaged") // pin to specific commit before annotations
-    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:2.0.0:repackaged") // use GitHub release via JitPack
+    implementation("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:2.0.0:repackaged") // use GitHub release via JitPack
 
-    api("com.github.Fraunhofer-AISEC:codyze:v2.0.1") // use GitHub release via JitPack
+    // Codyze v2 MARK evaluation
+    implementation("com.github.Fraunhofer-AISEC:codyze:main-SNAPSHOT") // use GitHub release via JitPack
 
     // TODO remove after moving to Kotlin
     // Reflections for OverflowDB and registering Crymlin built-ins
-    implementation("org.reflections", "reflections", "0.10.2")
+    //implementation("org.reflections", "reflections", "0.10.2")
 
     // TODO exchange with module
     // LSP interface support
-    api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0") // ok
+    //api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0") // ok
 }

--- a/codyze-v3/codyze-specification-languages/mark/src/main/kotlin/MarkExecutor.kt
+++ b/codyze-v3/codyze-specification-languages/mark/src/main/kotlin/MarkExecutor.kt
@@ -1,12 +1,12 @@
 package de.fraunhofer.aisec.codyze.specification_languages.mark
 
-import de.fraunhofer.aisec.codyze.legacy.analysis.AnalysisContext
-import de.fraunhofer.aisec.codyze.legacy.analysis.AnalysisServer
-import de.fraunhofer.aisec.codyze.legacy.analysis.FindingDescription
-import de.fraunhofer.aisec.codyze.legacy.analysis.ServerConfiguration
-import de.fraunhofer.aisec.codyze.legacy.analysis.TypestateMode as LegacyTypestateMode
-import de.fraunhofer.aisec.codyze.legacy.analysis.markevaluation.Evaluator
-import de.fraunhofer.aisec.codyze.legacy.markmodel.Mark
+import de.fraunhofer.aisec.codyze.analysis.AnalysisContext
+import de.fraunhofer.aisec.codyze.analysis.AnalysisServer
+import de.fraunhofer.aisec.codyze.analysis.FindingDescription
+import de.fraunhofer.aisec.codyze.analysis.ServerConfiguration
+import de.fraunhofer.aisec.codyze.analysis.TypestateMode as LegacyTypestateMode
+import de.fraunhofer.aisec.codyze.analysis.markevaluation.Evaluator
+import de.fraunhofer.aisec.codyze.markmodel.Mark
 import de.fraunhofer.aisec.codyze_core.Executor
 import de.fraunhofer.aisec.codyze_core.config.ExecutorConfiguration
 import de.fraunhofer.aisec.cpg.ExperimentalGraph

--- a/codyze-v3/codyze-specification-languages/mark/src/main/kotlin/MarkParser.kt
+++ b/codyze-v3/codyze-specification-languages/mark/src/main/kotlin/MarkParser.kt
@@ -1,8 +1,8 @@
 package de.fraunhofer.aisec.codyze.specification_languages.mark
 
-import de.fraunhofer.aisec.codyze.legacy.config.DisabledMarkRulesValue
-import de.fraunhofer.aisec.codyze.legacy.markmodel.Mark
-import de.fraunhofer.aisec.codyze.legacy.markmodel.MarkModelLoader
+import de.fraunhofer.aisec.codyze.config.DisabledMarkRulesValue
+import de.fraunhofer.aisec.codyze.markmodel.Mark
+import de.fraunhofer.aisec.codyze.markmodel.MarkModelLoader
 import de.fraunhofer.aisec.mark.XtextParser
 import java.nio.file.Path
 import kotlin.io.path.extension


### PR DESCRIPTION
- use JitPack release of v2 for MARK evaluation
- remove unnecessary dependencies
- update package name of MARK evaluation logic from v2