### PR TITLE
Add Version Provider for v3

### DIFF
--- a/codyze-v3/build.gradle.kts
+++ b/codyze-v3/build.gradle.kts
@@ -1,6 +1,6 @@
 allprojects {
     group = "de.fraunhofer.aisec.codyze"
-    version = if(version != "unspecified") version else "0.0.0-SNAPSHOT"
+    version = if(version != Project.DEFAULT_VERSION) version else "0.0.0-SNAPSHOT"
 }
 
 plugins {

--- a/codyze-v3/build.gradle.kts
+++ b/codyze-v3/build.gradle.kts
@@ -1,6 +1,6 @@
 allprojects {
     group = "de.fraunhofer.aisec.codyze"
-    version = System.getProperty("version") ?: "0.0.0-SNAPSHOT"
+    version = if(version != "unspecified") version else "0.0.0-SNAPSHOT"
 }
 
 plugins {

--- a/codyze-v3/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/codyze-v3/buildSrc/src/main/kotlin/module.gradle.kts
@@ -15,9 +15,7 @@ tasks.withType<Jar>().configureEach {
     manifest {
         attributes(
             "Implementation-Version" to project.version,
-            "Implementation-Vendor" to "Fraunhofer AISEC",
-            "Implementation-Vendor-Id" to project.group,
-            "Implementation-URL" to "https://github.com/Fraunhofer-AISEC/codyze"
+            "Implementation-Vendor" to "Fraunhofer AISEC"
         )
     }
 }

--- a/codyze-v3/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/codyze-v3/buildSrc/src/main/kotlin/module.gradle.kts
@@ -10,10 +10,15 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-// bundle codyze's version for all jars to use it at runtime
+// configure shared attributes for JAR file manifests
 tasks.withType<Jar>().configureEach {
     manifest {
-        attributes(mapOf("CodyzeVersion" to project.version))
+        attributes(
+            "Implementation-Version" to project.version,
+            "Implementation-Vendor" to "Fraunhofer AISEC",
+            "Implementation-Vendor-Id" to project.group,
+            "Implementation-URL" to "https://github.com/Fraunhofer-AISEC/codyze"
+        )
     }
 }
 

--- a/codyze-v3/codyze-core/build.gradle.kts
+++ b/codyze-v3/codyze-core/build.gradle.kts
@@ -17,3 +17,11 @@ dependencies {
     // The code in it was generated using https://app.quicktype.io/ with minor manual additions
     implementation(libs.sarif4k)
 }
+
+tasks {
+    jar {
+        manifest {
+            attributes("Implementation-Title" to "Codyze v3 - Core Library")
+        }
+    }
+}

--- a/codyze-v3/codyze-specification-languages/mark/build.gradle.kts
+++ b/codyze-v3/codyze-specification-languages/mark/build.gradle.kts
@@ -27,3 +27,11 @@ dependencies {
     // LSP interface support
     //api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0") // ok
 }
+
+tasks {
+    jar {
+        manifest {
+            attributes("Implementation-Title" to "Codyze v3 - Specification Language MARK")
+        }
+    }
+}

--- a/codyze-v3/codyze/build.gradle.kts
+++ b/codyze-v3/codyze/build.gradle.kts
@@ -37,8 +37,7 @@ application {
 tasks {
     jar {
         manifest {
-            attributes("Implementation-Title" to "codyze-v3",
-                "Implementation-Version" to archiveVersion.getOrElse("0.0.0-dev"))
+            attributes("Implementation-Title" to "Codyze v3")
         }
     }
 }

--- a/codyze-v3/codyze/build.gradle.kts
+++ b/codyze-v3/codyze/build.gradle.kts
@@ -42,6 +42,11 @@ tasks {
     }
 }
 
-tasks.named<JavaExec>("run") {                                         // 2
-    systemProperty("codyze-v3-version", findProperty("version") ?: "")
+/**
+ * Set version as system property when using run task, because there isn't a JAR file manifest.
+ *
+ * We already defined a sensible version in our parent project for all modules.
+ */
+tasks.named<JavaExec>("run") {
+    systemProperty("codyze-v3-version", project.version)
 }

--- a/codyze-v3/codyze/build.gradle.kts
+++ b/codyze-v3/codyze/build.gradle.kts
@@ -33,3 +33,16 @@ dependencies {
 application {
     mainClass.set("de.fraunhofer.aisec.codyze.MainKt")
 }
+
+tasks {
+    jar {
+        manifest {
+            attributes("Implementation-Title" to "codyze-v3",
+                "Implementation-Version" to archiveVersion.getOrElse("0.0.0-dev"))
+        }
+    }
+}
+
+tasks.named<JavaExec>("run") {                                         // 2
+    systemProperty("codyze-v3-version", findProperty("version") ?: "")
+}

--- a/codyze-v3/codyze/src/main/kotlin/Main.kt
+++ b/codyze-v3/codyze/src/main/kotlin/Main.kt
@@ -48,7 +48,7 @@ class ConfigFileParser : CliktCommand(treatUnknownOptionsAsArgs = true) {
 class CodyzeCli(val configFile: Path? = null) :
     CliktCommand(help = "Codyze finds security flaws in source code", printHelpOnEmptyArgs = true) {
     init {
-        versionOption(getVersion(), names = setOf("--version", "-V")) // TODO get actual version
+        versionOption(getVersion(), names = setOf("--version", "-V"))
         context {
             if (configFile != null)
                 valueSource = JsonValueSource.from(configFile, requireValid = true)

--- a/codyze-v3/codyze/src/main/kotlin/Main.kt
+++ b/codyze-v3/codyze/src/main/kotlin/Main.kt
@@ -79,7 +79,6 @@ class CodyzeCli(val configFile: Path? = null) :
         val version: String by lazy {
             System.getProperty("codyze-v3-version")
                 ?: run {
-                    var v = DEFAULT_VERSION
                     val resources: Enumeration<URL> =
                         CodyzeCli::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
                     while (resources.hasMoreElements()) {
@@ -91,14 +90,15 @@ class CodyzeCli(val configFile: Path? = null) :
                                 IMPLEMENTATION_TITLE ==
                                     mainAttributes.getValue(Attributes.Name.IMPLEMENTATION_TITLE)
                             ) {
-                                v = mainAttributes.getValue(Attributes.Name.IMPLEMENTATION_VERSION)
-                                break
+                                return@run mainAttributes.getValue(
+                                    Attributes.Name.IMPLEMENTATION_VERSION
+                                )
                             }
                         } catch (ex: IOException) {
                             logger.trace { "Unable to read from $url: $ex" }
                         }
                     }
-                    v
+                    DEFAULT_VERSION
                 }
         }
     }


### PR DESCRIPTION
This PR adds the version provider from v2 to v3 to get the project version from the manifest file.  If the `run` task is used, the project version is stored in and read from the `codyze-v3-version` system property.

The project version specified in gradle is also changed to resolving with the `-Pversion` property instead of a system property.