### PR TITLE
Fix Build & publish docs workflow

### DIFF
--- a/docs/mkdocs-material-plugins.txt
+++ b/docs/mkdocs-material-plugins.txt
@@ -1,2 +1,3 @@
 mkdocs-git-revision-date-localized-plugin
 mkdocs-glightbox
+mkdocs-minify-plugin


### PR DESCRIPTION
Add minify plugin to mkdocs-material-plugins.txt to fix Build & publish docs workflow