### PR TITLE
Delay package updates with renovate and enable dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,26 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard",
     ":assignAndReview(fwendland)",
     ":label(dependencies)",
     ":enableVulnerabilityAlerts",
     ":separateMultipleMajorReleases",
-    "docker:disableMajor"
+    "docker:disableMajor",
+    "npm:unpublishSafe"
   ],
-  "ignoreDeps": [
-    "de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark"
-  ],
-  "ignorePaths": ["codyze-v2/scripts", "docs"],
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
-      "matchPackagePrefixes": ["de.fraunhofer.aisec:cpg"],
-      "groupName": "CPG packages"
+      "matchDatasources": ["maven"],
+      "stabilityDays": 1
+    },
+    {
+      "groupName": "CPG packages",
+      "matchPackagePrefixes": ["de.fraunhofer.aisec:cpg"]
     },
     {
       "groupName": "picocli packages",
-      "matchPackagePatterns": ["^info.picocli:"]
+      "matchPackagePrefixes": ["info.picocli:"]
     },
     {
       "groupName": "VSCode plugin dependencies",


### PR DESCRIPTION
We're having some problems with Gradle plugin updates, where their dependencies on Maven are not yet available. We delay updates by 1 day. Vulnerabilities requiring immediate actions should still be raised immediately.

As per recommendation, we also enable the renovate dashboard.