### PR TITLE
Add retries and delay to dependency resolution

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,6 @@ jobs:
           python -m pip install mkdocs-material
           python -m pip install -r ./docs/mkdocs-material-plugins.txt
       - name: 'Build API pages'
-        run: ./gradlew :codyze-v2:dokkaHtml :codyze-v3:dokkaHtmlMultiModule
+        run: ./gradlew -Dorg.gradle.internal.repository.max.tentatives=5 -Dorg.gradle.internal.repository.initial.backoff=10000 :codyze-v2:dokkaHtml :codyze-v3:dokkaHtmlMultiModule
       - name: 'Build & deploy docs'
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
JitPack needs a few minutes to build the latest version. This causes
a timeout when resolving Codyze as dependency. We add additional retries
and increase the time between retries.

This is an inital guess for suitable parameters without causing the build
to take too long.