### PR TITLE
Restrict classpath of dependencies

### DIFF
--- a/codyze-v2/build.gradle.kts
+++ b/codyze-v2/build.gradle.kts
@@ -101,33 +101,33 @@ dependencies {
     // Logging
     implementation("org.slf4j:slf4j-api:2.0.0") // ok
     api("org.slf4j:log4j-over-slf4j:2.0.0") // needed for xtext.parser.antlr
-    api("org.apache.logging.log4j:log4j-core:2.18.0") // impl in main; used only in test
-    runtimeOnly("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.18.0") // impl in main; used only in test
+    runtimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0")
 
     // pull in explicitly to prevent mixing versions
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Code Property Graph
-    api("de.fraunhofer.aisec:cpg-core:4.6.2")
-    api("de.fraunhofer.aisec:cpg-analysis:4.6.2")
+    implementation("de.fraunhofer.aisec:cpg-core:4.6.2")
+    implementation("de.fraunhofer.aisec:cpg-analysis:4.6.2")
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
     //api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:bbd54a7b11:repackaged") // pin to specific commit before annotations
-    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:2.0.0:repackaged") // use GitHub release via JitPack
+    implementation("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:2.0.0:repackaged") // use GitHub release via JitPack
 
 
     // Pushdown Systems
-    api("de.breakpointsec:pushdown:1.1") // ok
+    implementation("de.breakpointsec:pushdown:1.1") // ok
 
     // LSP interface support
-    api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.15.0") // ok
+    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.15.0") // ok
 
     // Interactive console interface support using Jython (Scripting engine)
     implementation("org.python:jython-standalone:2.7.2") // ok
 
     // Command line interface support
-    api("info.picocli:picocli:4.6.3")
+    implementation("info.picocli:picocli:4.6.3")
     annotationProcessor("info.picocli:picocli-codegen:4.6.3")
 
     // Reflections for OverflowDB and registering Crymlin built-ins
@@ -142,7 +142,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
     // Parser for yaml configuration file
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4")
 }
 
 application {

--- a/codyze-v2/build.gradle.kts
+++ b/codyze-v2/build.gradle.kts
@@ -108,7 +108,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Code Property Graph
-    implementation("de.fraunhofer.aisec:cpg-core:4.6.2")
+    api("de.fraunhofer.aisec:cpg-core:4.6.2")
     implementation("de.fraunhofer.aisec:cpg-analysis:4.6.2")
 
     // MARK DSL (use fat jar). changing=true circumvents gradle cache

--- a/codyze-v2/build.gradle.kts
+++ b/codyze-v2/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     // documentation
     id("org.jetbrains.dokka") version "1.7.10"
 
-    kotlin("jvm") version "1.7.10" // we can only upgrade to Kotlin 1.5, if CPG does
+    kotlin("jvm") version "1.7.10"
 }
 
 group = "de.fraunhofer.aisec"
@@ -99,13 +99,16 @@ configurations.all {
 
 dependencies {
     // Logging
-    implementation("org.slf4j:slf4j-api:2.0.0") // ok
-    api("org.slf4j:log4j-over-slf4j:2.0.0") // needed for xtext.parser.antlr
-    implementation("org.apache.logging.log4j:log4j-core:2.18.0") // impl in main; used only in test
+    api("org.slf4j:slf4j-api:2.0.3") // e.g., exposed by de.fraunhofer.aisec.codyze.analysis.markevaluation.Evaluator
+    runtimeOnly("org.slf4j:log4j-over-slf4j:2.0.0") {
+        because("Needed for `xtext.parser.antlr`")
+    }
+    implementation("org.apache.logging.log4j:log4j-core:2.19.0") // used by main and test
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:2.19.0")
 
-    // pull in explicitly to prevent mixing versions
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    // kotlin
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("reflect")) // pull in explicitly to prevent mixing versions
 
     // Code Property Graph
     api("de.fraunhofer.aisec:cpg-core:4.6.2")
@@ -114,35 +117,33 @@ dependencies {
     // MARK DSL (use fat jar). changing=true circumvents gradle cache
     //api("de.fraunhofer.aisec.mark:de.fraunhofer.aisec.mark:1.4.0-SNAPSHOT:repackaged") { isChanging = true } // ok
     //api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:bbd54a7b11:repackaged") // pin to specific commit before annotations
-    implementation("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:2.0.0:repackaged") // use GitHub release via JitPack
-
+    api("com.github.Fraunhofer-AISEC.codyze-mark-eclipse-plugin:de.fraunhofer.aisec.mark:2.0.0:repackaged") // use GitHub release via JitPack; e.g. exposed by de.fraunhofer.aisec.cpg.analysis.fsm.FSMBuilder
 
     // Pushdown Systems
-    implementation("de.breakpointsec:pushdown:1.1") // ok
+    api("de.breakpointsec:pushdown:1.1") // e.g., exposed in de.fraunhofer.aisec.codyze.analysis.wpds
 
     // LSP interface support
-    implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.15.0") // ok
+    api("org.eclipse.lsp4j:org.eclipse.lsp4j:0.15.0") // e.g., exposed in de.fraunhofer.aisec.codyze.crymlin.connectors.lsp
 
     // Interactive console interface support using Jython (Scripting engine)
     implementation("org.python:jython-standalone:2.7.2") // ok
 
     // Command line interface support
-    implementation("info.picocli:picocli:4.6.3")
+    api("info.picocli:picocli:4.6.3") // e.g., exposed by de.fraunhofer.aisec.codyze.ManifestVersionProvider
     annotationProcessor("info.picocli:picocli-codegen:4.6.3")
 
     // Reflections for OverflowDB and registering Crymlin built-ins
-    implementation("org.reflections", "reflections", "0.10.2")
-
-    // Unit tests
-    testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
-    implementation(kotlin("stdlib-jdk8"))
+    implementation("org.reflections:reflections:0.10.2")
 
     // Parser for yaml configuration file
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4")
+
+    // Unit tests
+    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit5"))
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
 }
 
 application {

--- a/codyze-v2/scripts/performance_benchmark/analyzer/build.gradle
+++ b/codyze-v2/scripts/performance_benchmark/analyzer/build.gradle
@@ -71,7 +71,7 @@ task fatJar(type: Jar) {
 dependencies {
     compile group: "de.fraunhofer.aisec", name: "codyze", version: "+"
     compile group: "org.eclipse.jgit", name: "org.eclipse.jgit", version: "5.13.1.202206130422-r"
-    compile group: "org.slf4j", name: "jul-to-slf4j", version: "1.8.0-beta4"
+    compile group: "org.slf4j", name: "jul-to-slf4j", version: "2.0.2"
     compile group: "commons-cli", name: "commons-cli", version: "1.5.0"
     compile group: "redis.clients", name: "jedis", version: "3.9.0"
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
Multiple dependencies use the (transitive) `api` type, which convolutes the compile classpath of Codyze.

This PR aims to improve this by changing many dependencies to the `implementation` type, which adds those dependencies ti the runtime classpath only. This also prevents dependency issues further down the line (i.e. this PR fixes the logger warning mentioned in #264)

Additionally, this PR changes the Log4J 2 SLF4J Binding from `log4j-slf4j-impl` to `log4j-slf4j2-impl`, which should be used with SLF4J Versions 2.0.X+ (see [this entry](https://logging.apache.org/log4j/2.x/log4j-slf4j-impl/index.html))