### PR TITLE
Add JitPack repo URL for Renovate to fix package lookup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,10 @@
       "extends": ["schedule:earlyMondays"]
     },
     {
+      "matchPackagePrefixes": ["com.github.Fraunhofer-AISEC"],
+      "registryUrls": ["https://jitpack.io/"]
+    },
+    {
       "matchPackageNames": ["vscode"],
       "rangeStrategy": "bump",
       "allowedVersions": "<1.999.0"


### PR DESCRIPTION
Some of our dependencies are assembled directly from their GitHub project. We use JitPack to provide a Maven repo. However, the URL is not recognized by Renovate resulting in warnings. We're adding the URL explicitly to remove the warning.