### PR TITLE
Fix `executorOptionCastTest`

### DIFF
--- a/codyze-v3/codyze-core/src/main/kotlin/Project.kt
+++ b/codyze-v3/codyze-core/src/main/kotlin/Project.kt
@@ -2,20 +2,23 @@ package de.fraunhofer.aisec.codyze_core
 
 import de.fraunhofer.aisec.codyze_core.config.Configuration
 import io.github.detekt.sarif4k.*
+import org.koin.core.component.KoinComponent
 
 /**
  * An object that saves the context of an analysis.
  *
  * This enables switching between different analyses (e.g. switching between projects in an IDE).
  */
-class Project(val config: Configuration) {
+class Project(val config: Configuration) : KoinComponent {
     /** [Executor] that is capable of evaluating the [Configuration.spec] given in [config] */
     val executor = config.executor ?: getRandomCapableExecutor()
 
     /** Return the first registered Executor capable of evaluating [config.specFileExtension] */
     private fun getRandomCapableExecutor(): Executor {
         val randomCapableExecutor: Executor? =
-            ProjectServer.executors.find { it.supportedFileExtension == config.specFileExtension }
+            getKoin().getAll<Executor>().find {
+                it.supportedFileExtension == config.specFileExtension
+            }
         if (randomCapableExecutor != null) return randomCapableExecutor
         else
             throw RuntimeException(

--- a/codyze-v3/codyze-core/src/main/kotlin/ProjectServer.kt
+++ b/codyze-v3/codyze-core/src/main/kotlin/ProjectServer.kt
@@ -2,25 +2,16 @@ package de.fraunhofer.aisec.codyze_core
 
 import de.fraunhofer.aisec.codyze_core.config.Configuration
 import mu.KotlinLogging
-import org.koin.core.component.KoinComponent
 
 private val logger = KotlinLogging.logger {}
 
 /**
  * A server that manages [Project]s. Each [Configuration] corresponds to one potential [Project] .
  */
-object ProjectServer : KoinComponent {
+object ProjectServer {
 
     /** All projects that are connected to the server. */
     val projects: MutableMap<Configuration, Project> = mutableMapOf()
-    /** All built-in executors that are available for the analysis. */
-    val executors: List<Executor> = getKoin().getAll()
-
-    init {
-        logger.debug {
-            "Found executors for following file types: ${executors.map { it.supportedFileExtension }}"
-        }
-    }
 
     /**
      * Connect to the project associated with the given [Configuration] object.

--- a/codyze-v3/codyze/src/main/kotlin/options/CodyzeOptionGroup.kt
+++ b/codyze-v3/codyze/src/main/kotlin/options/CodyzeOptionGroup.kt
@@ -6,16 +6,17 @@ import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.path
 import de.fraunhofer.aisec.codyze_core.Executor
-import de.fraunhofer.aisec.codyze_core.ProjectServer
 import de.fraunhofer.aisec.codyze_core.config.ConfigurationRegister
 import de.fraunhofer.aisec.codyze_core.config.combineSources
 import de.fraunhofer.aisec.codyze_core.config.validateSpec
+import de.fraunhofer.aisec.codyze_core.log
 import java.nio.file.Path
 import kotlin.io.path.Path
+import org.koin.core.component.KoinComponent
 
 @Suppress("UNUSED")
 class CodyzeOptionGroup(configurationRegister: ConfigurationRegister) :
-    OptionGroup(name = "Codyze Options") {
+    OptionGroup(name = "Codyze Options"), KoinComponent {
     private val rawSpec: List<Path> by
         option("--spec", help = "Loads the given specification files.")
             .path(mustExist = true, mustBeReadable = true, canBeDir = true)
@@ -89,11 +90,19 @@ class CodyzeOptionGroup(configurationRegister: ConfigurationRegister) :
                 help =
                     "Manually choose Executor to use with the given spec files. If unspecified, Codyze randomly selects an executor capable of evaluating the given specification files."
             )
-            .choice(*(ProjectServer.executors.map { it.name }).toTypedArray(), ignoreCase = true)
+            .choice(
+                *(getKoin().getAll<Executor>().map { it.name }).toTypedArray(),
+                ignoreCase = true
+            )
             .convert {
-                it.let { ProjectServer.executors.first { executor -> executor.name == it } }
+                it.let { getKoin().getAll<Executor>().first { executor -> executor.name == it } }
             }
-            .also { configurationRegister.addOption("executor", it) }
+            .also {
+                configurationRegister.addOption("executor", it)
+                log.debug {
+                    "Found following executors: ${it.completionCandidates}"
+                }
+            }
 
     val output: Path by
         option("-o", "--output", help = "Write results to file. Use - for stdout.")


### PR DESCRIPTION
Removes executors from the `ProjectServer` and inject them into `Project` and `CodyzeOptionGroup` directly. 
This fixes the `executorOptionCastTest` that failed sometimes when the `ProjectServer` was instantiated before executors are defined in Koin.