### PR TITLE
Increase Gradle HTTP timeout for depencency resolution

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ org.gradle.jvmargs=-Xmx4096M
 kotlin.code.style=official
 
 # Gradle HTTP timeout for `-SNAPSHOT` from JitPack
-systemProp.org.gradle.internal.http.connectionTimeout=180000
-systemProp.org.gradle.internal.http.socketTimeout=180000
+systemProp.org.gradle.internal.http.connectionTimeout=180000 # 3 min
+systemProp.org.gradle.internal.http.socketTimeout=180000 # 3 min

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx4096M
 
 # Code style
 kotlin.code.style=official
+
+# Gradle HTTP timeout for `-SNAPSHOT` from JitPack
+systemProp.org.gradle.internal.http.connectionTimeout=180000
+systemProp.org.gradle.internal.http.socketTimeout=180000


### PR DESCRIPTION
Pulling in CPG as `-SNAPSHOT` through JitPack causes HTTP timeouts when JitPack needs to rebuild the package. FAQ states that one should increase Gradle's HTTP timeout (cf. https://docs.jitpack.io/faq/).