### PR TITLE
Remove end of line comment from `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.jvmargs=-Xmx4096M
 # Code style
 kotlin.code.style=official
 
-# Gradle HTTP timeout for `-SNAPSHOT` from JitPack
-systemProp.org.gradle.internal.http.connectionTimeout=180000 # 3 min
-systemProp.org.gradle.internal.http.socketTimeout=180000 # 3 min
+# Gradle HTTP timeout for `-SNAPSHOT` from JitPack -> 180000 ms == 3 min
+systemProp.org.gradle.internal.http.connectionTimeout=180000
+systemProp.org.gradle.internal.http.socketTimeout=180000


### PR DESCRIPTION
End of line comments in `gradle.properties` are considered part of a key's value. Currently, the alue cannot be interpreted and is ignored in favor of the default value of 30000 ms (30 sec).