### PR TITLE
Add comments to `OrderBuilder`

### DIFF
--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Order.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Order.kt
@@ -200,10 +200,12 @@ inline fun set(block: OrderSet.() -> Unit) = OrderSet(false).apply(block).apply 
 //
 context(OrderBuilder)
 /**
- * Appends an alternation token (`|`) to the current [OrderFragment].
+ * Adds an alternation token (`|`) between the current [OrderFragment] and [other].
+ * All [OrderToken] are converted into [OrderFragment]s.
  *
- * > Acts like a boolean OR. Matches the expression before or after the |. > It can operate within a
- * group, or on a whole expression. The patterns will be tested in order.
+ * Acts like a boolean OR. Matches the expression before or after the |.
+ *
+ * It can operate within a group, or on a whole expression. The patterns will be tested in order.
  */
 infix fun OrderFragment.or(other: OrderFragment): OrderFragment =
     this@OrderBuilder.add(AlternativeOrderNode(left = toNode(), right = other.toNode())).also {
@@ -213,11 +215,12 @@ infix fun OrderFragment.or(other: OrderFragment): OrderFragment =
 
 context(OrderBuilder)
 /**
- * Converts the [OrderToken] to an [OrderFragment] and appends an alternation token (`|`) to the
- * current [OrderFragment].
+ * Adds an alternation token (`|`) between the current [OrderToken] and [other].
+ * All [OrderToken] are converted into [OrderFragment]s.
  *
- * > Acts like a boolean OR. Matches the expression before or after the |. > It can operate within a
- * group, or on a whole expression. The patterns will be tested in order.
+ * Acts like a boolean OR. Matches the expression before or after the |.
+ *
+ * It can operate within a group, or on a whole expression. The patterns will be tested in order.
  */
 infix fun OrderToken.or(other: OrderFragment): OrderFragment =
     this@OrderBuilder.add(AlternativeOrderNode(left = token.toNode(), right = other.toNode())).also {
@@ -226,22 +229,24 @@ infix fun OrderToken.or(other: OrderFragment): OrderFragment =
 
 context(OrderBuilder)
 /**
- * Converts the [OrderToken] to an [OrderFragment] and appends an alternation token (`|`) to the
- * current [OrderFragment].
+ * Adds an alternation token (`|`) between the current [OrderToken] and [other].
+ * All [OrderToken] are converted into [OrderFragment]s.
  *
- * > Acts like a boolean OR. Matches the expression before or after the |. > It can operate within a
- * group, or on a whole expression. The patterns will be tested in order.
+ * Acts like a boolean OR. Matches the expression before or after the |.
+ *
+ * It can operate within a group, or on a whole expression. The patterns will be tested in order.
  */
 infix fun OrderToken.or(other: OrderToken): OrderFragment =
     this@OrderBuilder.add(AlternativeOrderNode(left = token.toNode(), right = other.token.toNode()))
 
 context(OrderBuilder)
 /**
- * Converts the [OrderToken] to an [OrderFragment] and appends an alternation token (`|`) to the
- * current [OrderFragment].
+ * Adds an alternation token (`|`) between the current [OrderFragment] and [other].
+ * All [OrderToken] are converted into [OrderFragment]s.
  *
- * > Acts like a boolean OR. Matches the expression before or after the |. > It can operate within a
- * group, or on a whole expression. The patterns will be tested in order.
+ * Acts like a boolean OR. Matches the expression before or after the |.
+ *
+ * It can operate within a group, or on a whole expression. The patterns will be tested in order.
  */
 infix fun OrderFragment.or(other: OrderToken): OrderFragment =
     this@OrderBuilder.add(AlternativeOrderNode(left = toNode(), right = other.token.toNode())).also {

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Order.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Order.kt
@@ -76,13 +76,15 @@ context(OrderBuilder)
 /** Adds a group with the [maybe] ('*') qualifier. See [group] */
 inline fun maybe(
     block: OrderGroup.() -> Unit,
-) = this@OrderBuilder.add(QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.MAYBE))
+): OrderNode = this@OrderBuilder.add(
+    QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.MAYBE)
+)
 
 context(OrderBuilder)
 /** Adds a group with the [option] ('?') qualifier. See [group] */
 inline fun option(
     block: OrderGroup.() -> Unit,
-) = this@OrderBuilder.add(
+): OrderNode = this@OrderBuilder.add(
     QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.OPTION)
 )
 
@@ -90,7 +92,7 @@ context(OrderBuilder)
 /** Adds a group with the [some] ('+') qualifier. See [group] */
 inline fun some(
     block: OrderGroup.() -> Unit,
-) = this@OrderBuilder.add(
+): OrderNode = this@OrderBuilder.add(
     QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.ATLEAST, value = 1)
 )
 
@@ -99,7 +101,7 @@ context(OrderBuilder)
 inline fun count(
     count: Int,
     block: OrderGroup.() -> Unit,
-) = this@OrderBuilder.add(
+): OrderNode = this@OrderBuilder.add(
     QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.COUNT, value = count)
 )
 
@@ -108,7 +110,7 @@ context(OrderBuilder)
 inline fun between(
     range: IntRange,
     block: OrderGroup.() -> Unit,
-) = this@OrderBuilder.add(
+): OrderNode = this@OrderBuilder.add(
     QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.BETWEEN, value = range)
 )
 
@@ -117,7 +119,7 @@ context(OrderBuilder)
 inline fun atLeast(
     count: Int,
     block: OrderGroup.() -> Unit,
-) = this@OrderBuilder.add(
+): OrderNode = this@OrderBuilder.add(
     QuantifierOrderNode(child = OrderGroup().apply(block).toNode(), type = OrderQuantifier.ATLEAST, value = count)
 )
 
@@ -130,31 +132,31 @@ inline fun atLeast(
  * }
  * ```
  */
-fun OrderBuilder.group(vararg tokens: OrderToken) = group { tokens.forEach { +it } }
+fun OrderBuilder.group(vararg tokens: OrderToken): OrderNode = group { tokens.forEach { +it } }
 
 context(OrderBuilder)
 /** Minimalist way to create a group with the [maybe] ('*') qualifier. See [group]. */
-fun maybe(vararg tokens: OrderToken) = maybe { tokens.forEach { +it } }
+fun maybe(vararg tokens: OrderToken): OrderNode = maybe { tokens.forEach { +it } }
 
 context(OrderBuilder)
 /** Minimalist way to create a group with the [some] ('+') qualifier. See [group]. */
-fun some(vararg tokens: OrderToken) = some { tokens.forEach { +it } }
+fun some(vararg tokens: OrderToken): OrderNode = some { tokens.forEach { +it } }
 
 context(OrderBuilder)
 /** Minimalist way to create a group with the [option] ('?') qualifier. See [group]. */
-fun option(vararg tokens: OrderToken) = option { tokens.forEach { +it } }
+fun option(vararg tokens: OrderToken): OrderNode = option { tokens.forEach { +it } }
 
 context(OrderBuilder)
 /** Minimalist way to create a group with the [count] qualifier. See [group]. */
-fun count(count: Int, vararg tokens: OrderToken) = count(count) { tokens.forEach { +it } }
+fun count(count: Int, vararg tokens: OrderToken): OrderNode = count(count) { tokens.forEach { +it } }
 
 context(OrderBuilder)
 /** Minimalist way to create a group with the [between] qualifier. See [group]. */
-fun between(range: IntRange, vararg tokens: OrderToken) = between(range) { tokens.forEach { +it } }
+fun between(range: IntRange, vararg tokens: OrderToken): OrderNode = between(range) { tokens.forEach { +it } }
 
 context(OrderBuilder)
 /** Minimalist way to create a group with the [atLeast] qualifier. See [group]. */
-fun atLeast(min: Int, vararg tokens: OrderToken) = atLeast(min) { tokens.forEach { +it } }
+fun atLeast(min: Int, vararg tokens: OrderToken): OrderNode = atLeast(min) { tokens.forEach { +it } }
 
 //
 // sets

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/ordering/OrderBuilder.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/ordering/OrderBuilder.kt
@@ -48,8 +48,8 @@ open class OrderBuilder : OrderFragment {
      * The reason why all instances of [fragment] are removed is to ensure consistent behavior of
      * [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or].
      * [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or] might receive [OrderFragment]s as arguments.
-     * If these [OrderFragment]s are built directly with the order dsl functions,
-     * [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or] must remove them from the [orderNodes] list.
+     * [OrderFragment]s can only be built with Order DSL functions which will add their resulting [OrderFragment] directly to the [orderNodes] list.
+     * This means that [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or] must remove the [OrderFragment]s from the [orderNodes] list to prevent them from appearing multiple times.
      * An example would be:
      * ```kt
      *  order {
@@ -58,7 +58,7 @@ open class OrderBuilder : OrderFragment {
      *  }
      * ```
      * The regex would be (a* (a* | b+)).
-     * If the [OrderFragment]s from `maybe(TestClass::fun1)` and `atLeast(TestClass::fun2)` were not removed from
+     * If the [OrderFragment]s from `maybe(TestClass::a)` and `some(TestClass::b)` were not removed from
      * the [orderNodes], the regex would be (a* a* b+ (a* | b+)) which is incorrect.
      *
      * However, problems arise if we consider a second example:
@@ -69,7 +69,7 @@ open class OrderBuilder : OrderFragment {
      *  }
      * ```
      * The desired regex would still be (a* (a* | b+)).
-     * However, this poses a problem for [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or].
+     * However, this is a problem for [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or].
      * It cannot differentiate if a [OrderFragment] was stored in a variable or not.
      * Therefore, the [OrderFragment] is always removed.
      * This means that the resulting regex is actually (a* | b+).

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/ordering/OrderBuilder.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/ordering/OrderBuilder.kt
@@ -48,8 +48,10 @@ open class OrderBuilder : OrderFragment {
      * The reason why all instances of [fragment] are removed is to ensure consistent behavior of
      * [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or].
      * [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or] might receive [OrderFragment]s as arguments.
-     * [OrderFragment]s can only be built with Order DSL functions which will add their resulting [OrderFragment] directly to the [orderNodes] list.
-     * This means that [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or] must remove the [OrderFragment]s from the [orderNodes] list to prevent them from appearing multiple times.
+     * [OrderFragment]s can only be built with Order DSL functions which will add their resulting [OrderFragment]
+     * directly to the [orderNodes] list.
+     * This means that [de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.or] must remove the
+     * [OrderFragment]s from the [orderNodes] list to prevent them from appearing multiple times.
      * An example would be:
      * ```kt
      *  order {


### PR DESCRIPTION
This PR improves the quality of the documentation of `order` DSL functions.
It also adds comments explaining the behavior of `OrderBuilder.add`.
