### PR TITLE
Change unary plus to unary minus

### DIFF
--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -103,14 +103,14 @@ class ConstructorOp internal constructor(val classFqn: String) : Op {
  * op {
  *   definition("my.fully.qualified.name") {
  *      signature {
- *          +arg1
- *          +arg2
- *          +arg3
+ *          - arg1
+ *          - arg2
+ *          - arg3
  *      }
  *      signature(arg1, arg2)
  *      signature {
- *          +arg2
- *          +arg3
+ *          - arg2
+ *          - arg3
  *      }
  *   }
  *   definition("my.other.function") {
@@ -141,7 +141,7 @@ fun constructor(classFqn: String, block: ConstructorOp.() -> Unit) =
  * A minimal example
  * ```kt
  * function {
- *   +definition("my.fully.qualified.name") {}
+ *   definition("my.fully.qualified.name") {}
  * }
  * ```
  *
@@ -166,13 +166,13 @@ inline fun Definition.signature(
  * Create a [Signature] which can be added to the [Definition]. The [Parameter]s are passed through
  * the vararg.
  */
-fun Definition.signature(vararg parameters: Parameter) = signature { parameters.forEach { +it } }
+fun Definition.signature(vararg parameters: Parameter) = signature { parameters.forEach { - it } }
 
 /** Create a [ParameterGroup] which can be added to the [Signature]. */
 inline fun Signature.group(block: ParameterGroup.() -> Unit) = ParameterGroup().apply(block).also { this.add(it) }
 
 /** Create a [ParameterGroup] which can be added to the [Signature]. */
-fun Signature.group(vararg parameters: Parameter) = group { parameters.forEach { +it } }
+fun Signature.group(vararg parameters: Parameter) = group { parameters.forEach { - it } }
 
 context(Definition)
 /** Add unordered [Parameter]s to the [Signature]. */
@@ -189,4 +189,4 @@ inline fun ConstructorOp.signature(block: Signature.() -> Unit) = Signature().ap
  * Create a [Signature] which can be added to the [ConstructorOp]. The [Parameter]s are passed
  * through the vararg.
  */
-fun ConstructorOp.signature(vararg parameters: Parameter) = signature { parameters.forEach { +it } }
+fun ConstructorOp.signature(vararg parameters: Parameter) = signature { parameters.forEach { - it } }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/OpComponents.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/OpComponents.kt
@@ -25,7 +25,7 @@ typealias Parameter = Any?
 class ParameterGroup {
     val parameters = arrayListOf<Parameter>()
 
-    operator fun Parameter.unaryPlus() {
+    operator fun Parameter.unaryMinus() {
         add(this)
     }
 
@@ -111,7 +111,7 @@ class Signature {
 
     val unorderedParameters = arrayListOf<Parameter>()
 
-    operator fun Parameter.unaryPlus() {
+    operator fun Parameter.unaryMinus() {
         add(this)
     }
 

--- a/codyze-specification-languages/coko/coko-core/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/OpDslTest.kt
+++ b/codyze-specification-languages/coko/coko-core/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/OpDslTest.kt
@@ -60,20 +60,20 @@ class OpDslTest {
 
         val actualOp = op {
             definition("fqn1") {
-                signature { +stringParam }
+                signature { - stringParam }
                 signature(stringParam, callTestParam)
                 signature {
-                    +stringParam
-                    +callTestParam
+                    - stringParam
+                    - callTestParam
                 }.unordered(numberParam)
                 signature(numberParam, collectionParam, stringParam)
             }
             definition("fqn2") {
                 signature {
-                    +typeParam
+                    - typeParam
                     group {
-                        +stringParam
-                        +arrayParam
+                        - stringParam
+                        - arrayParam
                     }
                 }
             }

--- a/codyze-specification-languages/coko/coko-core/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/OpComponentsTest.kt
+++ b/codyze-specification-languages/coko/coko-core/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/OpComponentsTest.kt
@@ -32,7 +32,7 @@ class OpComponentsTest {
     @MethodSource("unaryPlusParamHelper")
     fun `test group`(expectedParams: ArrayList<Parameter>) {
         with(mockk<Signature>(relaxed = true)) {
-            val paramGroup = group { expectedParams.forEach { +it } }
+            val paramGroup = group { expectedParams.forEach { - it } }
 
             assertContentEquals(expectedParams, paramGroup.parameters)
         }
@@ -44,7 +44,7 @@ class OpComponentsTest {
         expectedParams: ArrayList<Parameter>
     ) {
         val sig = Signature()
-        with(sig) { expectedParams.forEach { +it } }
+        with(sig) { expectedParams.forEach { - it } }
         assertContentEquals(
             expectedParams,
             sig.parameters,
@@ -55,7 +55,7 @@ class OpComponentsTest {
     @Test
     fun `test simple signature`() {
         with(mockk<Definition>(relaxed = true)) {
-            val sig = signature { +singleParam }
+            val sig = signature { - singleParam }
             val sigShortcut = signature(singleParam)
 
             val expectedSig = Signature().apply { parameters.add(singleParam) }
@@ -80,7 +80,7 @@ class OpComponentsTest {
     @Test
     fun `test signature with group`() {
         with(mockk<Definition>(relaxed = true)) {
-            val sig = signature { group { multipleParams.forEach { +it } } }
+            val sig = signature { group { multipleParams.forEach { - it } } }
 
             val groupShortcut = signature { group(*multipleParams.toTypedArray()) }
 
@@ -102,9 +102,9 @@ class OpComponentsTest {
         with(mockk<Definition>(relaxed = true)) {
             val sig =
                 signature {
-                    +singleParam
-                    group { grouped.forEach { +it } }
-                    ordered.forEach { +it }
+                    - singleParam
+                    group { grouped.forEach { - it } }
+                    ordered.forEach { - it }
                 }
                     .unordered(*unordered.toTypedArray())
 

--- a/codyze-specification-languages/coko/coko-dsl/src/main/resources/bouncycastle/CipherImpl.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/resources/bouncycastle/CipherImpl.codyze.kts
@@ -7,9 +7,9 @@ class CipherImpl : Cipher {
     // deal with the different function signatures with a more complex configuration of the
     // CallExpression
     op {
-        +definition("javax.crypto.Cipher.getInstance") {
-            +signature(transform)
-            +signature(transform, provider)
+        definition("javax.crypto.Cipher.getInstance") {
+            signature(transform)
+            signature(transform, provider)
         }
     }
 
@@ -21,44 +21,44 @@ class CipherImpl : Cipher {
         params: Any?, // optional
         paramspec: Any? // optional
     ) = op {
-        +definition("javax.crypto.Cipher.init") {
-            +signature(opmode, certificate)
-            +signature(opmode, certificate, random)
-            +signature(opmode, key)
-            +signature(opmode, key, params)
-            +signature(opmode, key, params, random)
-            +signature(opmode, key, random)
-            +signature(opmode, key, paramspec)
-            +signature(opmode, key, paramspec, random)
+        definition("javax.crypto.Cipher.init") {
+            signature(opmode, certificate)
+            signature(opmode, certificate, random)
+            signature(opmode, key)
+            signature(opmode, key, params)
+            signature(opmode, key, params, random)
+            signature(opmode, key, random)
+            signature(opmode, key, paramspec)
+            signature(opmode, key, paramspec, random)
         }
     }
 
     override fun aad(src: Any, vararg args: Any) = op {
-        +definition("javax.crypto.Cipher.updateAAD") {
-            +signature(src)
+        definition("javax.crypto.Cipher.updateAAD") {
+            signature(src)
             // TODO: signature(src, ...) in MARK
         }
     }
 
     override fun update(input: Any, output: Any?, vararg args: Any) = op {
-        +definition("javax.crypto.Cipher.update") {
-            +signature(input)
-            +signature(input, Wildcard, Wildcard)
-            +signature(input, Wildcard, Wildcard, output)
-            +signature(input, Wildcard, Wildcard, output, Wildcard)
-            +signature(input, output)
+        definition("javax.crypto.Cipher.update") {
+            signature(input)
+            signature(input, Wildcard, Wildcard)
+            signature(input, Wildcard, Wildcard, output)
+            signature(input, Wildcard, Wildcard, output, Wildcard)
+            signature(input, output)
         }
     }
 
     override fun finalize(input: Any?, output: Any?, vararg args: Any) = op {
-        +definition("javax.crypto.Cipher.doFinal") {
-            +signature()
-            +signature(input)
-            +signature(output, Wildcard)
-            +signature(input, Wildcard, Wildcard)
-            +signature(input, Wildcard, Wildcard, output)
-            +signature(input, Wildcard, Wildcard, output, Wildcard)
-            +signature(input, output)
+        definition("javax.crypto.Cipher.doFinal") {
+            signature()
+            signature(input)
+            signature(output, Wildcard)
+            signature(input, Wildcard, Wildcard)
+            signature(input, Wildcard, Wildcard, output)
+            signature(input, Wildcard, Wildcard, output, Wildcard)
+            signature(input, output)
         }
     }
 }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/IntegrationTests/CokoCpg/followedBy.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/IntegrationTests/CokoCpg/followedBy.codyze.kts
@@ -7,8 +7,8 @@ class JavaLoggingTest : LoggingForTest {
         definition("java.util.logging.Logger.info") {
             signature {
                 group {
-                    +message
-                    args.forEach { +it }
+                    - message
+                    args.forEach { - it }
                 }
             }
         }
@@ -20,8 +20,8 @@ class JDBCTest : ObjectRelationalMapperForTest {
         definition("java.sql.Statement.executeUpdate") {
             signature {
                 group {
-                    +"INSERT.*"
-                    +obj
+                    - "INSERT.*"
+                    - obj
                 }
             }
         }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/IntegrationTests/CokoCpg/followedByFull.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/IntegrationTests/CokoCpg/followedByFull.codyze.kts
@@ -23,8 +23,8 @@ class JavaLogging : Logging {
         definition("java.util.logging.Logger.info") {
             signature {
                 group {
-                    +message
-                    args.forEach { +it }
+                    - message
+                    args.forEach { - it }
                 }
             }
         }
@@ -36,8 +36,8 @@ class JDBC : ObjectRelationalMapper {
         definition("java.sql.Statement.executeUpdate") {
             signature {
                 group {
-                    +"INSERT.*"
-                    +obj
+                    - "INSERT.*"
+                    - obj
                 }
             }
         }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/javaimpl.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/javaimpl.codyze.kts
@@ -7,8 +7,8 @@ class JavaLogging : Logging {
         definition("java.util.logging.Logger.info") {
             signature {
                 group {
-                    +message
-                    args.forEach { +it }
+                    - message
+                    args.forEach { - it }
                 }
             }
         }
@@ -20,8 +20,8 @@ class JDBC : ObjectRelationalMapper {
         definition("java.sql.Statement.executeUpdate") {
             signature {
                 group {
-                    +"INSERT.*"
-                    +obj
+                    - "INSERT.*"
+                    - obj
                 }
             }
         }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/pyimpl.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/pyimpl.codyze.kts
@@ -8,7 +8,7 @@ class PythonLogging : Logging {
     // We don't care about the order of the arguments. Just make sure that all objects in "args"
     // somehow flow into the log message/args.
     op {
-        definition("logging.info") { signature(args) { +message } }
+        definition("logging.info") { signature(args) { - message } }
     }
 }
 
@@ -17,8 +17,8 @@ class Sqlite3 : ObjectRelationalMapper {
         definition("sqlite3.Cursor.execute") {
             signature {
                 group {
-                    +"INSERT.*"
-                    +obj
+                    - "INSERT.*"
+                    - obj
                 }
             }
         }


### PR DESCRIPTION
This PR changes all unary plus in the Coko DSL to unary minus. This way, adding `Parameters` to `Ops` or `OrderTokens` to the order looks like listing them with dashes which might be more intuitive.