### PR TITLE
Matrix Strategy for the Build Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+env:
+  DEFAULT_JAVA_VERSION: "17"
+
 on:
   push:
     branches:
@@ -14,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [ "11", "17", "20" ]
+        version: [ ${{ DEFAULT_JAVA_VERSION }}, "20" ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -45,7 +48,7 @@ jobs:
         with:
           arguments: :codyze-cli:build -x check --parallel -Pversion=${{ env.version }}
       - name: Push Release Docker Image
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "11" && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == ${{ DEFAULT_JAVA_VERSION }} && matrix.os == "ubuntu-latest"
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -t ghcr.io/fraunhofer-aisec/codyze:latest .
@@ -53,7 +56,7 @@ jobs:
           docker push ghcr.io/fraunhofer-aisec/codyze:${{ env.version }}
           docker push ghcr.io/fraunhofer-aisec/codyze:latest
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "11" && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == ${{ DEFAULT_JAVA_VERSION }} && matrix.os == "ubuntu-latest"
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         version: [ "17", "19" ]
         os: [ ubuntu-latest, macos-latest ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: build
 
-env:
-  DEFAULT_JAVA_VERSION: "17"
-
 on:
   push:
     branches:
@@ -17,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [ ${{ env.DEFAULT_JAVA_VERSION }}, "20" ]
+        version: [ "17", "20" ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -48,7 +45,7 @@ jobs:
         with:
           arguments: :codyze-cli:build -x check --parallel -Pversion=${{ env.version }}
       - name: Push Release Docker Image
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == env.DEFAULT_JAVA_VERSION && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "17" && matrix.os == "ubuntu-latest"
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -t ghcr.io/fraunhofer-aisec/codyze:latest .
@@ -56,7 +53,7 @@ jobs:
           docker push ghcr.io/fraunhofer-aisec/codyze:${{ env.version }}
           docker push ghcr.io/fraunhofer-aisec/codyze:latest
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == env.DEFAULT_JAVA_VERSION && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "17" && matrix.os == "ubuntu-latest"
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [ "17", "20" ]
+        version: [ "17", "19" ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        version: [ ${{ DEFAULT_JAVA_VERSION }}, "20" ]
+        version: [ ${{ env.DEFAULT_JAVA_VERSION }}, "20" ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         version: [ "17", "19" ]
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ "11", "17", "20" ]
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
     steps:
@@ -20,7 +24,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 17
+          java-version: ${{ matrix.version }}
       - name: Determine Version
         run: |
           # determine version from tag
@@ -41,7 +45,7 @@ jobs:
         with:
           arguments: :codyze-cli:build -x check --parallel -Pversion=${{ env.version }}
       - name: Push Release Docker Image
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "11" && matrix.os == "ubuntu-latest"
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -t ghcr.io/fraunhofer-aisec/codyze:latest .
@@ -49,7 +53,7 @@ jobs:
           docker push ghcr.io/fraunhofer-aisec/codyze:${{ env.version }}
           docker push ghcr.io/fraunhofer-aisec/codyze:latest
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "11" && matrix.os == "ubuntu-latest"
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           arguments: :codyze-cli:build -x check --parallel -Pversion=${{ env.version }}
       - name: Push Release Docker Image
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "17" && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == '17' && matrix.os == 'ubuntu-latest'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -t ghcr.io/fraunhofer-aisec/codyze:latest .
@@ -53,7 +53,7 @@ jobs:
           docker push ghcr.io/fraunhofer-aisec/codyze:${{ env.version }}
           docker push ghcr.io/fraunhofer-aisec/codyze:latest
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == "17" && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == '17' && matrix.os == 'ubuntu-latest'
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         version: [ "17", "19" ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           arguments: :codyze-cli:build -x check --parallel -Pversion=${{ env.version }}
       - name: Push Release Docker Image
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == ${{ DEFAULT_JAVA_VERSION }} && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == env.DEFAULT_JAVA_VERSION && matrix.os == "ubuntu-latest"
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker build -t ghcr.io/fraunhofer-aisec/codyze:latest .
@@ -56,7 +56,7 @@ jobs:
           docker push ghcr.io/fraunhofer-aisec/codyze:${{ env.version }}
           docker push ghcr.io/fraunhofer-aisec/codyze:latest
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == ${{ DEFAULT_JAVA_VERSION }} && matrix.os == "ubuntu-latest"
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.version == env.DEFAULT_JAVA_VERSION && matrix.os == "ubuntu-latest"
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.version }}


### PR DESCRIPTION
Add a matrix strategy to the build workflow. This helps ensuring smooth java version upgrades and can be used to check for OS incompatibilities.

The used java versions are Java 17 and 19 (newer versions are incompatible with the used Kotlin plugin).
Used OS are ubuntu-latest and macos-latest, including Windows is not yet possible with the way we try to resolve the version.

The resulting workflow run can be seen [here](https://github.com/Fraunhofer-AISEC/codyze/actions/runs/4573721733).
Compare #540 (transition to Java 17 already complete).

The strategy is configured in a way that ensures a single failing combination does not cancel other matrix combinations.