### PR TITLE
Add `never` evaluator

### DIFF
--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/CokoCpgBackend.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/CokoCpgBackend.kt
@@ -19,11 +19,13 @@ import de.fraunhofer.aisec.codyze.backends.cpg.CPGBackend
 import de.fraunhofer.aisec.codyze.backends.cpg.CPGConfiguration
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl.*
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.FollowsEvaluator
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.NeverEvaluator
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.OnlyEvaluator
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.OrderEvaluator
 import de.fraunhofer.aisec.codyze.core.VersionProvider
 import de.fraunhofer.aisec.codyze.core.backend.BackendConfiguration
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Evaluator
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Order
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.OrderToken
@@ -58,13 +60,13 @@ class CokoCpgBackend(config: BackendConfiguration) :
     }
 
     /** For each of the nodes in [this], there is a path to at least one of the nodes in [that]. */
-    override infix fun Op.followedBy(that: Op) = FollowsEvaluator(ifOp = this, thenOp = that)
+    override infix fun Op.followedBy(that: Op): FollowsEvaluator = FollowsEvaluator(ifOp = this, thenOp = that)
 
     /*
      * Ensures the order of nodes as specified in the user configured [Order] object.
      * The order evaluation starts at the given [baseNodes].
      */
-    override fun order(baseNodes: OrderToken, block: Order.() -> Unit) =
+    override fun order(baseNodes: OrderToken, block: Order.() -> Unit): OrderEvaluator =
         OrderEvaluator(
             baseNodes = baseNodes.getOp().cpgGetAllNodes(),
             order = Order().apply(block)
@@ -74,7 +76,7 @@ class CokoCpgBackend(config: BackendConfiguration) :
      * Ensures the order of nodes as specified in the user configured [Order] object.
      * The order evaluation starts at the given [baseNodes].
      */
-    override fun order(baseNodes: Op, block: Order.() -> Unit) =
+    override fun order(baseNodes: Op, block: Order.() -> Unit): OrderEvaluator =
         OrderEvaluator(
             baseNodes = baseNodes.cpgGetNodes(),
             order = Order().apply(block)
@@ -83,5 +85,6 @@ class CokoCpgBackend(config: BackendConfiguration) :
     /**
      * Ensures that all calls to the [ops] have arguments that fit the parameters specified in [ops]
      */
-    override fun only(vararg ops: Op) = OnlyEvaluator(ops.toList())
+    override fun only(vararg ops: Op): OnlyEvaluator = OnlyEvaluator(ops.toList())
+    override fun never(vararg ops: Op): NeverEvaluator = NeverEvaluator(ops.toList())
 }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/NeverEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/NeverEvaluator.kt
@@ -1,0 +1,58 @@
+package de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.EvaluationContext
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Evaluator
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.CpgFinding
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl.cpgGetNodes
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Rule
+import kotlin.reflect.full.findAnnotation
+
+context(CokoCpgBackend)
+class NeverEvaluator(val forbiddenOps: List<Op>): Evaluator {
+
+    /** Default message if a violation is found */
+    private val defaultFailMessage: String by lazy {
+        "Calls to ${forbiddenOps.joinToString()} are not allowed."
+    }
+
+    /** Default message if node complies with rule */
+    private val defaultPassMessage = "No calls to ${forbiddenOps.joinToString()} found which is in compliance with rule."
+
+    override fun evaluate(context: EvaluationContext): Collection<Finding> {
+        val ruleAnnotation = context.rule.findAnnotation<Rule>()
+        val failMessage = ruleAnnotation?.failMessage?.takeIf { it.isNotEmpty() } ?: defaultFailMessage
+        val passMessage = ruleAnnotation?.passMessage?.takeIf { it.isNotEmpty() } ?: defaultPassMessage
+
+        val findings = mutableListOf<CpgFinding>()
+
+        for(op in forbiddenOps) {
+            val nodes = op.cpgGetNodes()
+
+            if(nodes.isNotEmpty()) {
+                // This means there are calls to the forbidden op, so Fail findings are added
+                for(node in nodes) {
+                    findings.add(
+                        CpgFinding(
+                            message = "Violation against rule: \"${node.code}\". $failMessage",
+                            kind = Finding.Kind.Fail,
+                            node = node
+                        )
+                    )
+                }
+            }
+        }
+
+        // If there are no findings, there were no violations, so a Pass finding is added
+        if(findings.isEmpty())
+            findings.add(
+                CpgFinding(
+                    message = passMessage,
+                    kind = Finding.Kind.Pass,
+                )
+            )
+        return findings
+    }
+}

--- a/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/FollowsEvaluationTest.kt
+++ b/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/FollowsEvaluationTest.kt
@@ -126,7 +126,7 @@ class FollowsEvaluationTest {
             val backend = CokoCpgBackend(config = createCpgConfiguration(testFile))
 
             with(backend) {
-                val evaluator = FollowsEvaluator(fooInstance.first(), barInstance.second())
+                val evaluator = fooInstance.first() followedBy barInstance.second()
                 findings = evaluator.evaluate(
                     EvaluationContext(
                         rule = ::dummyRule,

--- a/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/NeverEvaluationTest.kt
+++ b/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/NeverEvaluationTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.aisec.codyze.backends.cpg
+
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.EvaluationContext
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.definition
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.op
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.signature
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+import kotlin.io.path.*
+import kotlin.reflect.full.valueParameters
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NeverEvaluationTest {
+
+    class FooModel {
+        fun first(i: Any) = op {
+            definition("Foo.first") {
+                signature(i)
+            }
+        }
+    }
+
+    @Test
+    fun `test never with violation`() {
+        val fooInstance = FooModel()
+
+        val backend = CokoCpgBackend(config = createCpgConfiguration(violationFile))
+
+        with(backend) {
+            // Evaluator does not allow calls to `first` with -1 or a number between 1230 and 1240
+            val evaluator = never(
+                fooInstance.first(-1),
+                fooInstance.first(1230..1240)
+            )
+            val findings = evaluator.evaluate(
+                EvaluationContext(
+                    rule = ::dummyRule,
+                    parameterMap = ::dummyRule.valueParameters.associateWith { fooInstance }
+                )
+            )
+
+            assertTrue("There were no findings which is unexpected") { findings.isNotEmpty() }
+
+            val failFindings = findings.filter { it.kind == Finding.Kind.Fail }
+            assertEquals(2, failFindings.size, "Found ${failFindings.size} violation(s) instead of two violations")
+        }
+    }
+
+    @Test
+    fun `test never with no violations`() {
+        val fooInstance = FooModel()
+
+        val backend = CokoCpgBackend(config = createCpgConfiguration(passFile))
+
+        with(backend) {
+            // Evaluator does not allow calls to `first` with -1 or a number between 1230 and 1240
+            val evaluator = never(
+                fooInstance.first(-1),
+                fooInstance.first(1230..1240)
+            )
+            val findings = evaluator.evaluate(
+                EvaluationContext(
+                    rule = ::dummyRule,
+                    parameterMap = ::dummyRule.valueParameters.associateWith { fooInstance }
+                )
+            )
+
+            assertTrue("There were no findings which is unexpected") { findings.isNotEmpty() }
+
+            assertTrue("Not all findings are passes which is unexpected: ${findings.joinToString()}") { findings.all { it.kind == Finding.Kind.Pass } }
+
+            assertEquals(1, findings.size, "Found ${findings.size} finding(s) instead of one pass finding")
+        }
+    }
+
+    companion object {
+
+        lateinit var violationFile: Path
+        lateinit var passFile: Path
+
+        @BeforeAll
+        @JvmStatic
+        fun startup() {
+            val classLoader = OnlyEvaluationTest::class.java.classLoader
+
+            val violationFileResource = classLoader.getResource("NeverEvaluationTest/NeverViolation.java")
+            assertNotNull(violationFileResource)
+            violationFile = Path(violationFileResource.path)
+
+            val passFileResource = classLoader.getResource("NeverEvaluationTest/NeverPass.java")
+            assertNotNull(passFileResource)
+            passFile = Path(passFileResource.path)
+        }
+    }
+}

--- a/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/OnlyEvaluationTest.kt
+++ b/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/OnlyEvaluationTest.kt
@@ -48,7 +48,7 @@ class OnlyEvaluationTest {
         val backend = CokoCpgBackend(config = createCpgConfiguration(testFile))
 
         with(backend) {
-            val evaluator = OnlyEvaluator(listOf(fooInstance.first(0..10)))
+            val evaluator = only(fooInstance.first(0..10))
             val findings = evaluator.evaluate(
                 EvaluationContext(
                     rule = ::dummyRule,

--- a/codyze-backends/cpg/src/test/resources/NeverEvaluationTest/NeverPass.java
+++ b/codyze-backends/cpg/src/test/resources/NeverEvaluationTest/NeverPass.java
@@ -1,0 +1,20 @@
+public class NeverPass {
+
+	public void ok() {
+		Foo f = new Foo();
+		f.first(2);
+		f.first(6);
+	}
+
+	public void ok2() {
+		Foo f = new Foo();
+		f.first(1);
+		f.first(123);
+	}
+
+}
+
+
+public class Foo {
+	public int first(int i) {}
+}

--- a/codyze-backends/cpg/src/test/resources/NeverEvaluationTest/NeverViolation.java
+++ b/codyze-backends/cpg/src/test/resources/NeverEvaluationTest/NeverViolation.java
@@ -1,0 +1,20 @@
+public class NeverViolation {
+
+	public void ok() {
+		Foo f = new Foo();
+		f.first(2);
+		f.first(6);
+	}
+
+	public void fail() {
+		Foo f = new Foo();
+		f.first(-1);
+		f.first(1234);
+	}
+
+}
+
+
+public class Foo {
+	public int first(int i) {}
+}

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
@@ -58,4 +58,7 @@ interface CokoBackend : Backend {
      * Ensures that all calls to the [ops] have arguments that fit the parameters specified in [ops]
      */
     fun only(vararg ops: Op): Evaluator
+
+    /** Ensures that there are no calls to the [ops] which have arguments that fit the parameters specified in [ops] */
+    fun never(vararg ops: Op): Evaluator
 }


### PR DESCRIPTION
This PR adds a new evaluator to Coko, the `never` evaluator. It verifies that the given `Ops` are never called in the analyzed code.