### PR TITLE
Transition to new group id for `kotlin-logging`

### DIFF
--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/CPGConfiguration.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/CPGConfiguration.kt
@@ -17,7 +17,7 @@ package de.fraunhofer.aisec.codyze.backends.cpg
 
 import de.fraunhofer.aisec.codyze.core.backend.BackendConfiguration
 import de.fraunhofer.aisec.cpg.passes.Pass
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 import kotlin.reflect.KClass
 

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/OrderEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/OrderEvaluator.kt
@@ -31,7 +31,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.*
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberFunctions
 

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/ordering/CodyzeDfaOrderEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/ordering/CodyzeDfaOrderEvaluator.kt
@@ -23,7 +23,7 @@ import de.fraunhofer.aisec.cpg.analysis.fsm.DFA
 import de.fraunhofer.aisec.cpg.analysis.fsm.DFAOrderEvaluator
 import de.fraunhofer.aisec.cpg.analysis.fsm.Edge
 import de.fraunhofer.aisec.cpg.graph.Node
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.reflect.full.findAnnotation
 
 val logger = KotlinLogging.logger {}

--- a/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/CpgOptionGroupTest.kt
+++ b/codyze-backends/cpg/src/test/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/CpgOptionGroupTest.kt
@@ -24,7 +24,7 @@ import de.fraunhofer.aisec.cpg.passes.CallResolver
 import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
 import de.fraunhofer.aisec.cpg.passes.FilenameMapper
 import de.fraunhofer.aisec.cpg.passes.Pass
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest

--- a/codyze-cli/src/main/kotlin/de/fraunhofer/aisec/codyze/cli/Main.kt
+++ b/codyze-cli/src/main/kotlin/de/fraunhofer/aisec/codyze/cli/Main.kt
@@ -18,7 +18,7 @@ package de.fraunhofer.aisec.codyze.cli
 import com.github.ajalt.clikt.core.subcommands
 import de.fraunhofer.aisec.codyze.core.backend.BackendCommand
 import de.fraunhofer.aisec.codyze.core.executor.ExecutorCommand
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.context.startKoin
 import org.koin.java.KoinJavaComponent.getKoin
 import java.nio.file.Path

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/core/VersionProvider.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/core/VersionProvider.kt
@@ -15,7 +15,7 @@
  */
 package de.fraunhofer.aisec.codyze.core
 
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.*
 
 private val logger = KotlinLogging.logger {}

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/core/config/Configuration.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/core/config/Configuration.kt
@@ -16,7 +16,7 @@
 package de.fraunhofer.aisec.codyze.core.config
 
 import de.fraunhofer.aisec.codyze.core.output.OutputBuilder
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 
 private val logger = KotlinLogging.logger {}

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoConfiguration.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoConfiguration.kt
@@ -17,7 +17,7 @@ package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
 
 import de.fraunhofer.aisec.codyze.core.executor.ExecutorConfiguration
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.cli.validateSpec
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 
 private val logger = KotlinLogging.logger { }

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
@@ -17,7 +17,7 @@ package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Import
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.*

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/cli/CokoOptionGroup.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/cli/CokoOptionGroup.kt
@@ -19,7 +19,7 @@ import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.path
 import de.fraunhofer.aisec.codyze.core.config.resolvePaths
 import de.fraunhofer.aisec.codyze.core.executor.ExecutorOptions
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 
 private val logger = KotlinLogging.logger {}

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
@@ -23,7 +23,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoConfigurat
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoSarifBuilder
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoScript
 import io.github.detekt.sarif4k.Run
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 import kotlin.script.experimental.api.*
 import kotlin.script.experimental.api.SourceCode

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/SpecEvaluator.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/SpecEvaluator.kt
@@ -19,7 +19,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoRule
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.EvaluationContext
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Rule
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.reflect.*
 import kotlin.reflect.full.*
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ cpg-language-java = { module = "de.fraunhofer.aisec:cpg-language-java", version.
 #cpg-analysis = { module = "com.github.Fraunhofer-AISEC.cpg:cpg-analysis", version.ref = "cpg"}
 #cpg-language-go = { module = "com.github.Fraunhofer-AISEC.cpg:cpg-language-go", version.ref = "cpg"}
 
-kotlin-logging = { module = "io.github.microutils:kotlin-logging-jvm", version = "3.0.5"}
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version = "5.1.0" }
 log4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j18-impl", version = "2.18.0"}
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "4.2.0"}
 koin = { module = "io.insert-koin:koin-core", version.ref = "koin"}


### PR DESCRIPTION
The group id has changed from `io.github.microutils` to `io.github.oshai`. At the same time the root package changed from `mu` to `io.github.oshai.kotlinlogging`.´

This PR updates the group id of the Maven package and updates the imports to the new root package.