### PR TITLE
Automatic synchronization of Eclipse CDT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  update-cdt-with-cpg:
+    if: ${{ github.event.label.name == 'dependencies' }
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 17
+      - name: Update Eclipse CDT
+        run: |
+          ./gradlew updateEclipseCDT
+          git config --global user.name 'Robert Haimerl'
+          git config --global user.email 'robert.haimerl@aisec.fraunhofer.de'
+          git commit -am "Update Eclipe CDT"
+          git push
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   update-cdt-with-cpg:
-    if: ${{ github.event.label.name == 'dependencies' }}
+    if: contains(github.event.pull_request.labels.*.name, '<label_name>')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   update-cdt-with-cpg:
-    if: ${{ github.event.label.name == 'dependencies' }
+    if: ${{ github.event.label.name == 'dependencies' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   update-cdt-with-cpg:
-    if: contains(github.event.pull_request.labels.*.name, '<label_name>')
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,8 +64,8 @@ val projectProps by tasks.registering(WriteProperties::class) {
 
 task("updateEclipseCDT") {
     doLast {
-        val cpgVersion = "8.0.0" //libs.versions.cpg
-        val url = "https://github.com/Fraunhofer-AISEC/cpg/blob/v${cpgVersion}/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts"
+        val cpgVersion = libs.versions.cpg
+        val url = "https://github.com/Fraunhofer-AISEC/cpg/blob/v${cpgVersion.get()}/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts"
         val downloadedFile = layout.buildDirectory.file("cpg-conventions").get().asFile
         ant.invokeMethod("get", mapOf("src" to url, "dest" to downloadedFile))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,9 +62,11 @@ val projectProps by tasks.registering(WriteProperties::class) {
     }
 }
 
+// parse the Eclipse CDT version used in the CPG and applies it to Codyze
 task("updateEclipseCDT") {
     doLast {
         val cpgVersion = libs.versions.cpg
+        // If the location of the repository definition changes, change this url
         val url = "https://github.com/Fraunhofer-AISEC/cpg/blob/v${cpgVersion.get()}/buildSrc/src/main/kotlin/cpg.common-conventions.gradle.kts"
         val downloadedFile = layout.buildDirectory.file("cpg-conventions").get().asFile
         ant.invokeMethod("get", mapOf("src" to url, "dest" to downloadedFile))
@@ -72,6 +74,7 @@ task("updateEclipseCDT") {
         val newRegex = "setUrl\\(\\\\\"https:\\/\\/download\\.eclipse\\.org\\/tools\\/cdt\\/releases\\/.*\\/plugins\\\\\"\\)".toRegex()
         val matchResult = newRegex.find(downloadedFile.readText())
 
+        // Include ALL files in codyze that define the CDT repository location
         val files = setOf(
             File("$rootDir/code-coverage-report/build.gradle.kts"),
             File("$rootDir/buildSrc/src/main/kotlin/module.gradle.kts")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,11 +94,6 @@ task("updateEclipseCDT") {
     }
 }
 
-// always run "updateEclipseCDT" before build
-tasks.named("build") {
-    dependsOn(tasks.named("updateEclipseCDT"))
-}
-
 // configure detekt to combine the results of all submodules into a single sarif file -> for github code scanning
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
     output.set(rootProject.layout.buildDirectory.file("reports/detekt/detekt.sarif"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ val projectProps by tasks.registering(WriteProperties::class) {
     description = "Write project properties in a file."
 
     // Set output file to build/project.properties
-    outputFile = file("$buildDir/codyze.properties")
+    destinationFile = file("${layout.buildDirectory}/codyze.properties")
     // Default encoding is ISO-8559-1, here we change it.
     encoding = "UTF-8"
     // Optionally we can specify the header comment.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,11 @@ task("updateEclipseCDT") {
     }
 }
 
+// always run "updateEclipseCDT" before build
+tasks.named("build") {
+    dependsOn(tasks.named("updateEclipseCDT"))
+}
+
 // configure detekt to combine the results of all submodules into a single sarif file -> for github code scanning
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
     output.set(rootProject.layout.buildDirectory.file("reports/detekt/detekt.sarif"))


### PR DESCRIPTION
This PR adds a gradle task that synchronizes the Eclipse CDT version Codyze uses with the version used by the CPG.

This gradle task is invoked in any PR with the "dependencies" label and any changes made by that task are pushed back onto that branch.