### PR TITLE
Fix run command for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
       - name: 'Build API pages'
         run: |
-            ./gradlew
-            dokkaHtmlMultiModule
-            -Dorg.gradle.internal.repository.max.tentatives=5
-            -Dorg.gradle.internal.repository.initial.backoff=10000
+            ./gradlew dokkaHtmlMultiModule \
+              -Dorg.gradle.internal.repository.max.tentatives=5 \
+              -Dorg.gradle.internal.repository.initial.backoff=10000
       - name: 'Build & deploy docs'
         run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,23 +11,26 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      # Ensure Java installation to run Gradle
+      - uses: actions/setup-java@v4
         with:
-          python-version: '3.x'
-      - uses: actions/cache@v4
-        with:
-          key: ${{ github.ref }}
-          path: .cache
-      - name: 'Install mkdocs-material and plugins'
-        run: |
-          python -m pip install mkdocs-material
-          python -m pip install -r ./docs/mkdocs-material-plugins.txt
-      - name: Setup Gradle
+          distribution: "temurin"
+          java-version: 17
+      - name: 'Setup Gradle'
         uses: gradle/actions/setup-gradle@v3
       - name: 'Build API pages'
         run: |
             ./gradlew dokkaHtmlMultiModule \
               -Dorg.gradle.internal.repository.max.tentatives=5 \
               -Dorg.gradle.internal.repository.initial.backoff=10000
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: './docs/mkdocs-material-plugins.txt'
+      - name: 'Install mkdocs-material and plugins'
+        run: |
+          python -m pip install mkdocs-material
+          python -m pip install -r ./docs/mkdocs-material-plugins.txt
       - name: 'Build & deploy docs'
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
Updating the Gradle action changed the execution syntax for the associated Gradle task. This introduced an error in the actual command to be executed. This fixes the run command.