### PR TITLE
Fix deprecated logging functions

### DIFF
--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/OrderEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/OrderEvaluator.kt
@@ -116,7 +116,7 @@ class OrderEvaluator(val baseNodes: Collection<Node>, val order: Order) : Evalua
         val usedBases =
             syntaxTree.filterIsInstanceToList<TerminalOrderNode>().map { it.baseName }.toSet()
         if (usedBases.size > 1) {
-            logger.warn("Order statement contains more than one base. Not supported.")
+            logger.warn { "Order statement contains more than one base. Not supported." }
             return emptySet()
         }
 

--- a/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/core/VersionProvider.kt
+++ b/codyze-core/src/main/kotlin/de/fraunhofer/aisec/codyze/core/VersionProvider.kt
@@ -37,7 +37,7 @@ object VersionProvider {
         if (
             !props.containsKey("project.name") || props.getProperty("project.name").lowercase() != "codyze"
         ) {
-            logger.warn("Could not find correct version properties file")
+            logger.warn { "Could not find correct version properties file" }
             props.clear()
         }
     }


### PR DESCRIPTION
`kotlin-logging` moved away from direct logging methods to lazy evaluated lambdas. Adjusting the affected message to remove warnings during compilation.