### PR TITLE
Fix deprecated Gradle features

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ val projectProps by tasks.registering(WriteProperties::class) {
     description = "Write project properties in a file."
 
     // Set output file to build/project.properties
-    outputFile = file("$buildDir/codyze.properties")
+    destinationFile = file("${layout.buildDirectory.get()}/codyze.properties")
     // Default encoding is ISO-8559-1, here we change it.
     encoding = "UTF-8"
     // Optionally we can specify the header comment.
@@ -62,7 +62,7 @@ val projectProps by tasks.registering(WriteProperties::class) {
     }
 }
 
-// configure detekt to combine the results of all submodules into a single sarif file -> for github code scanning
+// configure detekt to combine the results of all submodules into a single sarif file -> for GitHub code scanning
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
     output.set(rootProject.layout.buildDirectory.file("reports/detekt/detekt.sarif"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ val projectProps by tasks.registering(WriteProperties::class) {
     description = "Write project properties in a file."
 
     // Set output file to build/project.properties
-    destinationFile = file("${layout.buildDirectory.get()}/codyze.properties")
+    destinationFile = layout.buildDirectory.file("codyze.properties")
     // Default encoding is ISO-8559-1, here we change it.
     encoding = "UTF-8"
     // Optionally we can specify the header comment.

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     // Unit tests
     testImplementation(kotlin("test"))
     testImplementation(libs.junit.params)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 repositories {


### PR DESCRIPTION
Fixes two deprecated Gradle features:

1. No longer uses `WriteProperties.outputFile` and `buildDir`.
2. Explicitly list test framework dependencies for JUnit 5 (cf. https://docs.gradle.org/8.6/userguide/upgrading_version_8.html#test_framework_implementation_dependencies).