### PR TITLE
Fix upgrade workflow

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build
         run:  ./gradlew :codyze-cli:build -x check --parallel -Pversion=0.0.0
         # step-level 'continue-on-error' needed to mask a negative workflow result
-        continue-on-error: true
+        # continue-on-error: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: include JAVA SE 21 (LTS) on release
-        version: [ "19", "20" ]
+        version: [ "19", "20", "21" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
-    name: 'Building with Java ${{ matrix.version }} on ${{ matrix.os }}'
+    name: 'Building with Java ${{ matrix.java-lts }} on ${{ matrix.os }}'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,7 +26,9 @@ jobs:
           java-version: ${{ matrix.version }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build
+      - name: Build Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: gradlew.bat :codyze-cli:build -x check --parallel -Pversion=0.0.0
+      - name: Build Default
+        if: ${{ !startsWith(matrix.os, 'windows') }}
         run:  ./gradlew :codyze-cli:build -x check --parallel -Pversion=0.0.0
-        # step-level 'continue-on-error' needed to mask a negative workflow result
-        # continue-on-error: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -3,7 +3,7 @@ name: java-upgrade
 on:
   schedule:
     # runs at 00:01 on the first every month
-    - cron: '1 0 1 * ?'
+    - cron: '1 0 1 * *'
   # can be triggered manually
   workflow_dispatch:
 

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,9 +1,19 @@
-name: java-upgrade
+# Portability testing across OSes and newer Java versions
+# ---
+# Regularly check if we remain compatible with other OSes than Linux and if we
+# could upgrade to newer versions of Java.
+#
+# This acts more like an indicator if something is going to break. Our main
+# target platform is Linux and we build against it during our regular workflow
+# runs. Likewise, we're just testing if we could support newer version of
+# Java. We're still taking very deliberate decisions to move to newer (LTS)
+# versions of Java.
+name: 'Portability testing OSes and Java versions'
 
 on:
   schedule:
-    # runs at 00:01 on the first every month
-    - cron: '1 0 1 * *'
+    # runs every Monday at 5:00
+    - cron: '0 5 * * 1'
   # can be triggered manually
   workflow_dispatch:
 
@@ -12,10 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "19", "20", "21" ]
+        version: [ "18", "19", "20", "21", "22" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
+    name: 'Building with Java ${{ matrix.version }} on ${{ matrix.os }}'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -10,6 +10,8 @@
 # LTS version of Java.
 name: 'Portability testing OSes and Java LTS versions'
 
+permissions: {}
+
 on:
   schedule:
     # runs at 5:00 on the first of every month

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -40,4 +40,34 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build and Test
+        id: build-and-test
         run:  ./gradlew build --parallel
+      - if: ${{ failure() }}
+        run: touch failure
+      - if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-${{ matrix.java-lts }}-failure
+          path: failure
+          if-no-files-found: ignore
+          retention-days: 1
+
+  process-failures:
+    if: ${{ !cancelled() }}
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get failures from matrix jobs
+        uses: actions/download-artifact@v4
+        with:
+          path: all-failures
+          pattern: '*-failure'
+          merge-multiple: true
+      - name: Process failures
+        id: process-failures
+        run: test -f all-failures/failure && echo 'hasFails=true' >> "$GITHUB_OUTPUT"
+      - if: ${{ steps.process-failures.outputs.hasFails == 'true' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Some matrix jobs failed.')

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,9 +26,5 @@ jobs:
           java-version: ${{ matrix.version }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-#      - name: Build Windows
-#        if: ${{ startsWith(matrix.os, 'windows') }}
-#        run: gradlew.bat :codyze-cli:build -x check --parallel -Pversion=0.0.0
-      - name: Build Default
-#        if: ${{ !startsWith(matrix.os, 'windows') }}
-        run:  ./gradlew build -x check --parallel
+      - name: Build and Test
+        run:  ./gradlew build --parallel

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,9 +26,9 @@ jobs:
           java-version: ${{ matrix.version }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-      - name: Build Windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: gradlew.bat :codyze-cli:build -x check --parallel -Pversion=0.0.0
+#      - name: Build Windows
+#        if: ${{ startsWith(matrix.os, 'windows') }}
+#        run: gradlew.bat :codyze-cli:build -x check --parallel -Pversion=0.0.0
       - name: Build Default
-        if: ${{ !startsWith(matrix.os, 'windows') }}
-        run:  ./gradlew :codyze-cli:build -x check --parallel -Pversion=0.0.0
+#        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run:  ./gradlew build -x check --parallel

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,19 +1,19 @@
-# Portability testing across OSes and newer Java versions
+# Portability testing across OSes and Java LTS versions
 # ---
 # Regularly check if we remain compatible with other OSes than Linux and if we
-# could upgrade to newer versions of Java.
+# could upgrade to newer LTS versions of Java.
 #
 # This acts more like an indicator if something is going to break. Our main
 # target platform is Linux and we build against it during our regular workflow
-# runs. Likewise, we're just testing if we could support newer version of
-# Java. We're still taking very deliberate decisions to move to newer (LTS)
-# versions of Java.
-name: 'Portability testing OSes and Java versions'
+# runs. Likewise, we're just testing if we could support newer LTS version of
+# Java. We're still taking very deliberate decisions to upgrade to the next
+# LTS version of Java.
+name: 'Portability testing OSes and Java LTS versions'
 
 on:
   schedule:
-    # runs every Monday at 5:00
-    - cron: '0 5 * * 1'
+    # runs at 5:00 on the first of every month
+    - cron: '0 5 1 * *'
   # can be triggered manually
   workflow_dispatch:
 
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "18", "19", "20", "21", "22" ]
+        java-lts: [ '17', '21' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
@@ -30,11 +30,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Java ${{ matrix.version }}
+      - name: Setup Java ${{ matrix.java-lts }}
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: ${{ matrix.version }}
+          java-version: ${{ matrix.java-lts }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build and Test


### PR DESCRIPTION
Semi-recent restructurings in the project repository broke the `upgrade` workflow that checks the build on different OS with different Java versions.

This PR fixes the workflow and removes the masking of negative results on job-level so that such breaks can be easier found in the future.

This PR also changes the workflow slightly in that the unit tests are now executed when building.