### PR TITLE
Fix first start documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To actually run Codyze you must specify a subcommand:
 ```shell
 $ ./gradlew run --args="--config=config.json runCoko cokoCpg"
 ```
-This will run the `runCoko` subcommand with the `cokoCpg` backend using the demo config file [`./codyze-cli/config.json`](./codyze-cli/codyze.json).
+This will run the `runCoko` subcommand with the `cokoCpg` backend using the demo config file [`./codyze-cli/config.json`](./codyze-cli/config.json).
 
 For more information, please refer to the [documentation](https://www.codyze.io).
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ This will print the help message and return an error.
 
 To actually run Codyze you must specify a subcommand:
 ```shell
-$ ./gradlew run --args="analyze"
+$ ./gradlew run --args="--config=config.json runCoko cokoCpg"
 ```
-This will run the 'analyze' subcommand using the demo config file [`./codyze-cli/codyze.json`](./codyze-cli/codyze.json).
+This will run the `runCoko` subcommand with the `cokoCpg` backend using the demo config file [`./codyze-cli/config.json`](./codyze-cli/codyze.json).
 
 For more information, please refer to the [documentation](https://www.codyze.io).
 

--- a/docs/Getting Started/configuration.md
+++ b/docs/Getting Started/configuration.md
@@ -17,7 +17,7 @@ To append the data from the command line to the one from the configuration file,
 ## Configuration File
 The configurations can also be defined with a JSON configuration file. 
 Use the option `--config=<filepath>` to specify the path to the config file.
-The configuration from `codyze.json` will always be loaded if no other file is specified.
+The configuration from `./codyze.json` will always be loaded if no other file is specified.
 
 Relative paths in the configuration file are resolved relative to the configuration file location.
 

--- a/docs/Getting Started/configuration.md
+++ b/docs/Getting Started/configuration.md
@@ -17,7 +17,7 @@ To append the data from the command line to the one from the configuration file,
 ## Configuration File
 The configurations can also be defined with a JSON configuration file. 
 Use the option `--config=<filepath>` to specify the path to the config file.
-The configuration from `./codyze.json` will always be loaded if no other file is specified.
+The configuration from `codyze.json` will always be loaded if no other file is specified.
 
 Relative paths in the configuration file are resolved relative to the configuration file location.
 
@@ -35,6 +35,14 @@ The configuration structure separates the options by subcommand as seen below.
 ```
 In this example the `good-findings` argument belongs to Codyze, the `spec` argument belongs to the `runCoko` subcommand and the `source` argument belongs to the `cokoCpg` subcommand.
 The value of the option is taken from the object which corresponds to the subcommand used for the execution.
+
+It is important to note that the configuration file only sets the options for each subcommand but does not invoke the subcommand itself.
+A complete usage example for using a configuration file in combination with subcommands looks as follows:
+```shell
+./gradlew :codyze-cli:run --args="--config=config.json runCoko cokoCpg"
+```
+Mind that the config file must be specified as a top-level argument before calling the respective subcommands for the `executor` or `backend`.
+
 An exemplary configuration file can also be found in the [GitHub repository <i class="fas fa-external-link-alt"></i>](https://github.com/Fraunhofer-AISEC/codyze/blob/main/codyze-cli/config.json){target=_blank}.
 
 ## List of Configurations


### PR DESCRIPTION
Updates outdated first start information from the README.

Also updates the documentation to make the correct usage of the configuration file more clear.