### PR TITLE
Implement initial PoC for checking return values

### DIFF
--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/CokoCpgBackend.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/CokoCpgBackend.kt
@@ -18,15 +18,15 @@ package de.fraunhofer.aisec.codyze.backends.cpg.coko
 import de.fraunhofer.aisec.codyze.backends.cpg.CPGBackend
 import de.fraunhofer.aisec.codyze.backends.cpg.CPGConfiguration
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl.*
-import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.FollowsEvaluator
-import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.NeverEvaluator
-import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.OnlyEvaluator
-import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.OrderEvaluator
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators.*
 import de.fraunhofer.aisec.codyze.core.VersionProvider
 import de.fraunhofer.aisec.codyze.core.backend.BackendConfiguration
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.WheneverEvaluator
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Condition
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Order
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ConditionComponent
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.OrderToken
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.getOp
 import de.fraunhofer.aisec.cpg.graph.Node
@@ -86,4 +86,13 @@ class CokoCpgBackend(config: BackendConfiguration) :
      */
     override fun only(vararg ops: Op): OnlyEvaluator = OnlyEvaluator(ops.toList())
     override fun never(vararg ops: Op): NeverEvaluator = NeverEvaluator(ops.toList())
+    override fun whenever(
+        premise: Condition.() -> ConditionComponent,
+        assertionBlock: WheneverEvaluator.() -> Unit
+    ): WheneverEvaluator = CpgWheneverEvaluator(Condition().premise()).apply(assertionBlock)
+
+    override fun whenever(
+        premise: ConditionComponent,
+        assertionBlock: WheneverEvaluator.() -> Unit
+    ): WheneverEvaluator = CpgWheneverEvaluator(premise).apply(assertionBlock)
 }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
@@ -34,7 +34,7 @@ fun DataItem<*>.cpgGetAllNodes(): Nodes =
     when (this@DataItem) {
         is ReturnValueItem -> op.cpgGetAllNodes().flatMap { it.getVariableInNextDFGOrThis() }
         is Value -> this@DataItem.getNodes()
-        is ArgumentItem -> TODO()
+        is ArgumentItem -> op.cpgGetAllNodes().map { it.arguments[index] } // TODO: Do we count starting at 0 or 1?
     }
 
 /**
@@ -45,7 +45,7 @@ fun DataItem<*>.cpgGetNodes(): Nodes {
     return when (this@DataItem) {
         is ReturnValueItem -> op.cpgGetNodes().flatMap { it.getVariableInNextDFGOrThis() }
         is Value -> this@DataItem.getNodes()
-        is ArgumentItem -> TODO()
+        is ArgumentItem -> op.cpgGetNodes().map { it.arguments[index] } // TODO: Do we count starting at 0 or 1?
     }
 }
 

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
@@ -1,0 +1,55 @@
+package de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl
+
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.DataItem
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ReturnValueItem
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Value
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
+import de.fraunhofer.aisec.cpg.graph.evaluate
+import de.fraunhofer.aisec.cpg.graph.literals
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
+import de.fraunhofer.aisec.cpg.graph.variables
+
+/**
+ * Get all [Nodes] that are associated with this [DataItem].
+ */
+context(CokoBackend)
+fun DataItem.cpgGetAllNodes(): Nodes =
+    when (this@DataItem) {
+        is ReturnValueItem -> op.cpgGetAllNodes().flatMap { it.getVariableInNextDFGOrThis() }
+        is Value -> this@DataItem.getNodes()
+    }
+
+/**
+ * Get all [Nodes] that are associated with this [DataItem].
+ */
+context(CokoBackend)
+fun DataItem.cpgGetNodes(): Nodes {
+    return when (this@DataItem) {
+        is ReturnValueItem -> op.cpgGetNodes().flatMap { it.getVariableInNextDFGOrThis() }
+        is Value -> this@DataItem.getNodes()
+    }
+}
+
+context(CokoBackend)
+private fun Value.getNodes(): Nodes =
+    cpg.literals.filter {
+            node ->
+        node.value == this.value
+    } + cpg.variables.filter {
+            node ->
+        node.evaluate() == this.value
+    }
+
+/**
+ * Returns all [VariableDeclaration]s and [DeclaredReferenceExpression]s that have a DFG edge from [this].
+ * If there are none, returns [this].
+ */
+private fun Node.getVariableInNextDFGOrThis(): Nodes =
+    this.nextDFG
+        .filter {
+                next ->
+            next is DeclaredReferenceExpression || next is VariableDeclaration
+        }.ifEmpty { listOf(this) }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl
 
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
@@ -49,6 +49,9 @@ fun DataItem<*>.cpgGetNodes(): Nodes {
     }
 }
 
+/**
+ * Get all [Nodes] that evaluate to the same value as [Value.value].
+ */
 context(CokoBackend)
 private fun Value<*>.getNodes(): Nodes {
     val value = this.value

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl
 
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes
@@ -24,7 +23,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Ret
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Value
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Reference
 
 /**
  * Get all [Nodes] that are associated with this [DataItem].
@@ -74,5 +73,5 @@ private fun Node.getVariableInNextDFGOrThis(): Nodes =
     this.nextDFG
         .filter {
                 next ->
-            next is DeclaredReferenceExpression || next is VariableDeclaration
+            next is Reference || next is VariableDeclaration
         }.ifEmpty { listOf(this) }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/DataItemCpgDsl.kt
@@ -18,46 +18,50 @@ package de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl
 
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ArgumentItem
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.DataItem
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ReturnValueItem
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Value
-import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.VariableDeclaration
-import de.fraunhofer.aisec.cpg.graph.evaluate
-import de.fraunhofer.aisec.cpg.graph.literals
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.DeclaredReferenceExpression
-import de.fraunhofer.aisec.cpg.graph.variables
 
 /**
  * Get all [Nodes] that are associated with this [DataItem].
  */
 context(CokoBackend)
-fun DataItem.cpgGetAllNodes(): Nodes =
+fun DataItem<*>.cpgGetAllNodes(): Nodes =
     when (this@DataItem) {
         is ReturnValueItem -> op.cpgGetAllNodes().flatMap { it.getVariableInNextDFGOrThis() }
         is Value -> this@DataItem.getNodes()
+        is ArgumentItem -> TODO()
     }
 
 /**
  * Get all [Nodes] that are associated with this [DataItem].
  */
 context(CokoBackend)
-fun DataItem.cpgGetNodes(): Nodes {
+fun DataItem<*>.cpgGetNodes(): Nodes {
     return when (this@DataItem) {
         is ReturnValueItem -> op.cpgGetNodes().flatMap { it.getVariableInNextDFGOrThis() }
         is Value -> this@DataItem.getNodes()
+        is ArgumentItem -> TODO()
     }
 }
 
 context(CokoBackend)
-private fun Value.getNodes(): Nodes =
-    cpg.literals.filter {
-            node ->
-        node.value == this.value
-    } + cpg.variables.filter {
-            node ->
-        node.evaluate() == this.value
+private fun Value<*>.getNodes(): Nodes {
+    val value = this.value
+    return if (value is Node) {
+        listOf(value)
+    } else {
+        cpg.literals.filter { node ->
+            node.value == value
+        } + cpg.variables.filter { node ->
+            node.evaluate() == value
+        }
     }
+}
 
 /**
  * Returns all [VariableDeclaration]s and [DeclaredReferenceExpression]s that have a DFG edge from [this].

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
@@ -47,6 +47,7 @@ fun Op.cpgGetAllNodes(): Nodes =
         is FunctionOp ->
             this@Op.definitions.flatMap { def -> this@CokoBackend.cpgCallFqn(def.fqn) }
         is ConstructorOp -> this@CokoBackend.cpgConstructor(this.classFqn)
+        is GroupingOp -> this@Op.ops.flatMap { it.cpgGetAllNodes() }
     }
 
 /**
@@ -74,6 +75,7 @@ fun Op.cpgGetNodes(): Nodes =
                             sig.unorderedParameters.all { it?.cpgFlowsTo(arguments) ?: false }
                     }
                 }
+        is GroupingOp -> this@Op.ops.flatMap { it.cpgGetNodes() }
     }
 
 /** Returns a list of [ValueDeclaration]s with the matching name. */

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
@@ -21,16 +21,11 @@ import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoMarker
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.*
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Definition
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ParameterGroup
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Signature
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
 import de.fraunhofer.aisec.cpg.TranslationResult
 import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.CallExpression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.ConstructExpression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
-import de.fraunhofer.aisec.cpg.graph.statements.expressions.MemberExpression
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.query.dataFlow
 
 //
@@ -191,8 +186,10 @@ fun CallExpression.cpgSignature(vararg parameters: Any?, hasVarargs: Boolean = f
                         parameter.param cpgFlowsTo arguments[i]
                 // checks if the type of the argument is the same
                 is Type -> cpgCheckType(parameter, i)
-                // check if any of the Nodes from the Op flow to the argument
+                // check if any of the Nodes of the Op flow to the argument
                 is Op -> parameter.cpgGetNodes() cpgFlowsTo arguments[i]
+                // check if any of the Nodes of the DataItem flow to the argument
+                is DataItem -> parameter.cpgGetNodes() cpgFlowsTo arguments[i]
                 // checks if there is dataflow from the parameter to the argument in the same position
                 else -> parameter cpgFlowsTo arguments[i]
             }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
@@ -189,7 +189,7 @@ fun CallExpression.cpgSignature(vararg parameters: Any?, hasVarargs: Boolean = f
                 // check if any of the Nodes of the Op flow to the argument
                 is Op -> parameter.cpgGetNodes() cpgFlowsTo arguments[i]
                 // check if any of the Nodes of the DataItem flow to the argument
-                is DataItem -> parameter.cpgGetNodes() cpgFlowsTo arguments[i]
+                is DataItem<*> -> parameter.cpgGetNodes() cpgFlowsTo arguments[i]
                 // checks if there is dataflow from the parameter to the argument in the same position
                 else -> parameter cpgFlowsTo arguments[i]
             }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/dsl/ImplementationDsl.kt
@@ -27,6 +27,7 @@ import de.fraunhofer.aisec.cpg.graph.*
 import de.fraunhofer.aisec.cpg.graph.declarations.ValueDeclaration
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.*
 import de.fraunhofer.aisec.cpg.query.dataFlow
+import de.fraunhofer.aisec.cpg.query.executionPath
 
 //
 // all functions/properties defined here must use CokoBackend
@@ -37,7 +38,7 @@ val CokoBackend.cpg: TranslationResult
 
 /** Get all [Nodes] that are associated with this [Op]. */
 context(CokoBackend)
-fun Op.cpgGetAllNodes(): Nodes =
+fun Op.cpgGetAllNodes(): Collection<CallExpression> =
     when (this@Op) {
         is FunctionOp ->
             this@Op.definitions.flatMap { def -> this@CokoBackend.cpgCallFqn(def.fqn) }
@@ -59,7 +60,7 @@ fun Op.cpgGetAllNodes(): Nodes =
  * [Definition]s.
  */
 context(CokoBackend)
-fun Op.cpgGetNodes(): Nodes =
+fun Op.cpgGetNodes(): Collection<CallExpression> =
     when (this@Op) {
         is FunctionOp ->
             this@Op.definitions
@@ -85,7 +86,8 @@ fun Op.cpgGetNodes(): Nodes =
             val conditionNodes = conditionOp.cpgGetNodes()
             resultNodes.filter { resultNode ->
                 conditionNodes.any { conditionNode ->
-                    val result = dataFlow(conditionNode, resultNode) // TODO
+                    // TODO: Is it correct to use the EOG relationship here?
+                    val result = executionPath(conditionNode, resultNode)
                     result.value
                 }
             }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators
+
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl.cpgGetNodes
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.modelling.toBackendDataItem
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.EvaluationContext
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.WheneverEvaluator
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
+import de.fraunhofer.aisec.cpg.graph.Node
+
+context(de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend)
+class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(premise) {
+    override fun evaluate(context: EvaluationContext): Collection<Finding> {
+        val (premiseNodes, premiseProblems) = evaluateConditionNodeToCpgNodes(premise)
+
+
+
+
+        TODO("Not yet implemented")
+    }
+
+    private fun evaluateConditionNodeToCpgNodes(conditionNode: ConditionNode): Pair<Nodes, Problems> {
+       return  when (conditionNode) {
+            is ConditionComponent -> evaluateConditionComponentToCpgNodes(conditionNode)
+            is ArgumentItem<*> -> TODO()
+            is ReturnValueItem<*> -> TODO()
+            is Value<*> -> evaluateValue(conditionNode)
+        }
+
+    }
+
+    private fun evaluateValue(value: Value<*>): Pair<Nodes, Problems> {
+        return listOf(DummyNode()) to Problems()
+    }
+
+    private fun evaluateConditionComponentToCpgNodes(conditionComponent: ConditionComponent): Pair<Nodes, Problems> {
+        return when (conditionComponent) {
+            is BinaryLogicalConditionComponent -> evaluateBinaryLogicalConditionComponent(conditionComponent)
+            is ComparisonConditionComponent -> evaluateComparisonConditionComponent(conditionComponent)
+            is UnaryConditionComponent -> TODO()
+            is CallConditionComponent -> evaluateCallConditionComponent(conditionComponent)
+            is ContainsConditionComponent<*, *> -> TODO()
+        }
+    }
+
+    private fun evaluateCallConditionComponent(callConditionComponent: CallConditionComponent): Pair<Nodes, Problems> {
+        return callConditionComponent.op.cpgGetNodes() to Problems()
+    }
+
+    private fun evaluateBinaryLogicalConditionComponent(
+        binaryLogicalConditionComponent: BinaryLogicalConditionComponent
+    ): Pair<Nodes, Problems> {
+        val (leftNodes, leftProblems) = evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.left)
+        val (rightNodes, rightProblems) = evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.right)
+        return when (binaryLogicalConditionComponent.operator) {
+            BinaryLogicalOperatorName.AND -> (leftNodes intersect rightNodes) to (leftProblems + rightProblems)
+            BinaryLogicalOperatorName.OR -> (leftNodes union rightNodes) to (leftProblems + rightProblems)
+        }
+    }
+
+    private fun evaluateComparisonConditionComponent(
+        comparisonConditionComponent: ComparisonConditionComponent
+    ): Pair<Nodes, Problems> {
+        val (leftNodes, leftProblems) = evaluateConditionNodeToCpgNodes(comparisonConditionComponent.left)
+        val (rightNodes, rightProblems) = evaluateConditionNodeToCpgNodes(comparisonConditionComponent.right)
+
+        val leftNodesToValues = leftNodes.associateWith {
+            comparisonConditionComponent.left.transformation(
+                it.toBackendDataItem()
+            )
+        }
+        val rightNodesToValues = rightNodes.associateWith {
+            comparisonConditionComponent.right.transformation(
+                it.toBackendDataItem()
+            )
+        }
+
+        return when (comparisonConditionComponent.operator) {
+            ComparisonOperatorName.GEQ -> TODO()
+            ComparisonOperatorName.GT -> TODO()
+            ComparisonOperatorName.LEQ -> TODO()
+            ComparisonOperatorName.LT -> TODO()
+            ComparisonOperatorName.EQ ->
+                (leftNodesToValues
+                    .filter { (_, value) -> rightNodesToValues.containsValue(value) }
+                    .keys) to (leftProblems + rightProblems)
+            ComparisonOperatorName.NEQ ->
+                (leftNodesToValues
+                    .filterNot { (_, value) -> rightNodesToValues.containsValue(value) }
+                    .keys) to (leftProblems + rightProblems)
+        }
+    }
+
+    class Problems {
+        val map: MutableMap<Any, String> = mutableMapOf()
+
+        fun add(reason: String, value: Any) {
+            map[value] = reason
+        }
+
+        operator fun plus(other: Problems): Problems {
+            map.putAll(other.map)
+            return this
+        }
+    }
+
+    class DummyNode: Node()
+}

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
@@ -65,8 +65,10 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
         } else {
             for (premiseNode in premiseNodes) {
                 val ensuresToNodes = ensures.associateWith { ensure ->
-                    val (ensureNodes, problems) = evaluateConditionComponentToCpgNodes(ensure, premiseNode)
-                    ensureNodes.filterNot { it is DummyNode } to problems
+                    evaluateConditionComponentToCpgNodes(
+                        ensure,
+                        premiseNode
+                    ).removeDummyNodes()
                 }
                 val callAssertionsToNodes = callAssertions.associateWith { callAssertion ->
                     val nodes = callAssertion.op.cpgGetNodes()
@@ -83,7 +85,8 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
                             Scope.Block -> TODO()
                         }
                     }
-                    nodes.toList() to Problems()
+                    TODO()
+                    EvaluationResult(nodes, emptyList(), Problems())
                 }
                 findings.addAll(
                     generateFindings(premiseNode, ensuresToNodes + callAssertionsToNodes, passMessage, failMessage)
@@ -96,32 +99,34 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
 
     private fun generateFindings(
         premiseNode: Node,
-        conditionToNodes: Map<ConditionComponent, Pair<List<Node>, Problems>>,
+        conditionToNodes: Map<ConditionComponent, EvaluationResult>,
         passMessage: String,
         failMessage: String
     ): Collection<Finding> {
         val findings = mutableListOf<Finding>()
 
-        val unfulfilledConditions = conditionToNodes.filterValues { (nodes, _) -> nodes.isEmpty() }
+        val unfulfilledConditions = conditionToNodes.filterValues { (fulfilled, _, _) -> fulfilled.isEmpty() }
 
         if (unfulfilledConditions.isNotEmpty()) {
             for ((condition, nodesToProblems) in unfulfilledConditions) {
-                val (_, problems) = nodesToProblems
-                if (problems.isEmpty()) {
-                    findings.add(
-                        CpgFinding(
-                            message = "No $condition found around $premise. $failMessage",
-                            kind = Finding.Kind.Fail,
-                            node = premiseNode
-                        )
-                    )
-                    TODO("Better message")
-                } else {
+                val (_, unfulfilled, problems) = nodesToProblems
+                if (problems.isNotEmpty()) {
                     findings.add(
                         CpgFinding(
                             message = "There were problems in resolving $condition. $problems",
                             kind = Finding.Kind.Open,
                             node = premiseNode,
+                            relatedNodes = problems.getNodes()
+                        )
+                    )
+                } else {
+                    // TODO: Better message
+                    findings.add(
+                        CpgFinding(
+                            message = "No $condition found around $premise. $failMessage",
+                            kind = Finding.Kind.Fail,
+                            node = premiseNode,
+                            relatedNodes = unfulfilled
                         )
                     )
                 }
@@ -132,9 +137,21 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
                     message = passMessage,
                     kind = Finding.Kind.Pass,
                     node = premiseNode,
-                    relatedNodes = conditionToNodes.values.flatMap { it.first }
+                    relatedNodes = conditionToNodes.values.flatMap { it.fulfillingNodes }
                 )
             )
+
+            val conditionToProblems = conditionToNodes.mapValues { (_, result) -> result.problems }
+            for ((condition, problems) in conditionToProblems) {
+                if (problems.isNotEmpty()) {
+                    CpgFinding(
+                        message = "There were problems in resolving $condition. $problems",
+                        kind = Finding.Kind.Informational,
+                        node = premiseNode,
+                        relatedNodes = problems.getNodes()
+                    )
+                }
+            }
         }
 
         return findings
@@ -143,8 +160,7 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
     private fun evaluateConditionNodeToCpgNodes(
         conditionNode: ConditionNode,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
-        TODO("change to EvaluationResult")
+    ): EvaluationResult {
         return when (conditionNode) {
             is ConditionComponent -> evaluateConditionComponentToCpgNodes(conditionNode, premiseNode)
             is ArgumentItem<*> -> evaluateArgumentItemToCpgNodes(conditionNode, premiseNode)
@@ -153,30 +169,30 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
         }
     }
 
-    private fun evaluateValueToCpgNodes(value: Value<*>, premiseNode: Node? = null): Pair<Nodes, Problems> {
-        return listOf(DummyNode()) to Problems()
+    private fun evaluateValueToCpgNodes(value: Value<*>, premiseNode: Node? = null): EvaluationResult {
+        return EvaluationResult(listOf(DummyNode()), emptyList(), Problems())
     }
 
     private fun evaluateArgumentItemToCpgNodes(
         argumentItem: ArgumentItem<*>,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
+    ): EvaluationResult {
         val nodes = argumentItem.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
-        return nodes to Problems()
+        return EvaluationResult(nodes, emptyList(), Problems())
     }
 
     private fun evaluateReturnValueItemToCpgNodes(
         returnValueItem: ReturnValueItem<*>,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
+    ): EvaluationResult {
         val nodes = returnValueItem.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
-        return nodes to Problems()
+        return EvaluationResult(nodes, emptyList(), Problems())
     }
 
     private fun evaluateConditionComponentToCpgNodes(
         conditionComponent: ConditionComponent,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
+    ): EvaluationResult {
         return when (conditionComponent) {
             is BinaryLogicalConditionComponent ->
                 evaluateBinaryLogicalConditionComponent(conditionComponent, premiseNode)
@@ -190,74 +206,97 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
     private fun evaluateBinaryLogicalConditionComponent(
         binaryLogicalConditionComponent: BinaryLogicalConditionComponent,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
-        val (leftNodes, leftProblems) =
+    ): EvaluationResult {
+        val (leftFulfillingNodes, leftUnfulfillingNodes, leftProblems) =
             evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.left, premiseNode)
-        val (rightNodes, rightProblems) =
+        val (rightFulfillingNodes, rightUnfulfillingNodes, rightProblems) =
             evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.right, premiseNode)
         return when (binaryLogicalConditionComponent.operator) {
-            BinaryLogicalOperatorName.AND -> (leftNodes intersect rightNodes) to (leftProblems + rightProblems)
-            BinaryLogicalOperatorName.OR -> (leftNodes union rightNodes) to (leftProblems + rightProblems)
+            BinaryLogicalOperatorName.AND ->
+                EvaluationResult(
+                    leftFulfillingNodes intersect rightFulfillingNodes.toSet(),
+                    leftUnfulfillingNodes union rightUnfulfillingNodes,
+                    leftProblems + rightProblems
+                )
+            BinaryLogicalOperatorName.OR ->
+                EvaluationResult(
+                    leftFulfillingNodes union rightFulfillingNodes,
+                    leftUnfulfillingNodes union rightUnfulfillingNodes,
+                    leftProblems + rightProblems
+                )
         }
     }
 
     private fun evaluateComparisonConditionComponent(
         comparisonConditionComponent: ComparisonConditionComponent,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
-        val (leftNodes, leftProblems) =
+    ): EvaluationResult {
+        val (leftFulfillingNodes, leftUnfulfillingNodes, leftProblems) =
             evaluateConditionNodeToCpgNodes(comparisonConditionComponent.left, premiseNode)
-        val (rightNodes, rightProblems) =
+        val (rightFulfillingNodes, rightUnfulfillingNodes, rightProblems) =
             evaluateConditionNodeToCpgNodes(comparisonConditionComponent.right, premiseNode)
 
         val newProblems = Problems()
-        val result = mutableSetOf<Node>()
+        val newFulfillingNodes = mutableSetOf<Node>()
+        val newUnfulfillingNodes = mutableSetOf<Node>()
 
         val leftNodesToValues =
-            leftNodes.toNodesToValues(newProblems, comparisonConditionComponent.left.transformation)
+            leftFulfillingNodes.toNodesToValues(newProblems, comparisonConditionComponent.left.transformation)
         val rightNodesToValues =
-            rightNodes.toNodesToValues(newProblems, comparisonConditionComponent.right.transformation)
+            rightFulfillingNodes.toNodesToValues(newProblems, comparisonConditionComponent.right.transformation)
 
         for ((leftNode, leftValue) in leftNodesToValues) {
-            for ((rightNode, rightValue) in rightNodesToValues)
-                when (comparisonConditionComponent.operator) {
-                    ComparisonOperatorName.GEQ -> TODO()
-                    ComparisonOperatorName.GT -> TODO()
-                    ComparisonOperatorName.LEQ -> TODO()
-                    ComparisonOperatorName.LT -> TODO()
-                    ComparisonOperatorName.EQ ->
-                        if (leftValue == rightValue) {
-                            result.add(leftNode)
-                            result.add(rightNode)
-                        }
-                    ComparisonOperatorName.NEQ -> TODO()
+//            for ((rightNode, rightValue) in rightNodesToValues)
+            when (comparisonConditionComponent.operator) {
+                ComparisonOperatorName.GEQ -> TODO()
+                ComparisonOperatorName.GT -> TODO()
+                ComparisonOperatorName.LEQ -> TODO()
+                ComparisonOperatorName.LT -> TODO()
+                ComparisonOperatorName.EQ -> {
+                    val (fulfilling, unfulfilling) =
+                        rightNodesToValues.toList().partition { (_, rightValue) -> leftValue == rightValue }
+                    newFulfillingNodes.addAll(fulfilling.map { it.first })
+                    newUnfulfillingNodes.addAll(unfulfilling.map { it.first })
+                    if (fulfilling.isEmpty()) {
+                        newUnfulfillingNodes.add(
+                            leftNode
+                        )
+                    } else {
+                        newFulfillingNodes.add(leftNode)
+                    }
                 }
+                ComparisonOperatorName.NEQ -> TODO()
+            }
         }
 
-        return result to (leftProblems + rightProblems + newProblems)
+        return EvaluationResult(
+            newFulfillingNodes,
+            leftUnfulfillingNodes + rightUnfulfillingNodes + newUnfulfillingNodes,
+            leftProblems + rightProblems + newProblems
+        )
     }
 
     private fun evaluateCallConditionComponent(
         callConditionComponent: CallConditionComponent,
         premiseNode: Node? = null
-    ): Pair<Nodes, Problems> {
+    ): EvaluationResult {
         val callNodes = callConditionComponent.op.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
-        return callNodes to Problems()
+        return EvaluationResult(callNodes, emptyList(), Problems())
     }
 
     private fun evaluateContainsConditionComponent(
         containsConditionComponent: ContainsConditionComponent<*, *>,
         premiseNode: Node?
-    ): Pair<Nodes, Problems> {
+    ): EvaluationResult {
         val problems = Problems()
         val nodes = containsConditionComponent.item.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
-        val resultNodes = nodes.filter { node ->
+        val (fulfilling, unfulfilling) = nodes.partition { node ->
             val backendDataItem = node.toBackendDataItem()
             val transformationResult = containsConditionComponent.item.transformation(backendDataItem)
             if (transformationResult.isFailure) {
                 problems.add(
                     transformationResult.getFailureReasonOrNull() ?: "Transformation of $backendDataItem failed",
-                    backendDataItem
+                    node
                 )
                 false
             } else {
@@ -266,7 +305,7 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
             }
         }
 
-        return resultNodes to Problems()
+        return EvaluationResult(fulfilling, unfulfilling, problems)
     }
 
     private fun Nodes.toNodesToValues(
@@ -280,7 +319,7 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
             val transformationResult = transformation(backendDataItem)
             val value = transformationResult.getValueOrNull()
             if (value == null) {
-                problems.add(transformationResult.getFailureReasonOrNull() ?: "Value was null", backendDataItem)
+                problems.add(transformationResult.getFailureReasonOrNull() ?: "Value was null", node)
             } else {
                 result[node] = value
             }
@@ -314,16 +353,16 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
     }
 
     class Problems {
-        private val map: MutableMap<BackendDataItem, String> = mutableMapOf()
+        private val map: MutableMap<Node, String> = mutableMapOf()
 
-        fun add(reason: String, value: BackendDataItem) {
+        fun add(reason: String, value: Node) {
             map[value] = reason
         }
 
-        fun getProblems(): Map<BackendDataItem, String> = map
+        fun getNodes(): Nodes = map.keys
 
-        fun isEmpty(): Boolean {
-            return map.isEmpty()
+        fun isNotEmpty(): Boolean {
+            return map.isNotEmpty()
         }
 
         operator fun plus(other: Problems): Problems {
@@ -332,21 +371,33 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
         }
 
         override fun toString(): String {
-            return map.toString()
+            return map.mapKeys { (node, _) -> node.toBackendDataItem() }.toString()
         }
     }
 
-    class EvaluationResult() {
-        val fulfillingNodes: MutableList<Node> = mutableListOf()
-        val unfulfillingNodes: MutableList<Node> = mutableListOf()
+    data class EvaluationResult(
+        val fulfillingNodes: MutableList<Node> = mutableListOf(),
+        val unfulfillingNodes: MutableList<Node> = mutableListOf(),
         val problems: Problems = Problems()
+    ) {
+        constructor(
+            fulfillingNodes: Nodes,
+            unfulfillingNodes: Nodes,
+            problems: Problems
+        ) : this(fulfillingNodes.toMutableList(), unfulfillingNodes.toMutableList(), problems)
 
-        constructor(fulfillingNodes: Nodes, unfulfillingNodes: Nodes, problems: Problems): this() {
-            this.fulfillingNodes.addAll(fulfillingNodes)
-            this.unfulfillingNodes.addAll(unfulfillingNodes)
-            this.problems + problems
+        operator fun plus(other: EvaluationResult): EvaluationResult {
+            fulfillingNodes.addAll(other.fulfillingNodes)
+            unfulfillingNodes.addAll(other.unfulfillingNodes)
+            problems + other.problems
+            return this
         }
 
+        fun removeDummyNodes(): EvaluationResult {
+            fulfillingNodes.removeIf { it is DummyNode }
+            unfulfillingNodes.removeIf { it is DummyNode }
+            return this
+        }
     }
 
     class DummyNode : Node()

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
@@ -90,7 +90,7 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
                         }
                     }
                     TODO()
-                    EvaluationResult(nodes, emptyList(), Problems())
+                    // EvaluationResult(nodes, emptyList(), Problems())
                 }
                 findings.addAll(
                     generateFindings(premiseNode, ensuresToNodes + callAssertionsToNodes, passMessage, failMessage)
@@ -187,6 +187,7 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
     /**
      * Finds the nodes that are represented by [value].
      */
+    @Suppress("style.UnusedParameter")
     private fun evaluateValueToCpgNodes(value: Value<*>, premiseNode: Node? = null): EvaluationResult {
         // We return a [DummyNode] here because Value objects don't use the information from the backend
         // for their transformation.

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators
 
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.CpgFinding
@@ -29,6 +28,7 @@ import de.fraunhofer.aisec.cpg.query.executionPath
 import kotlin.reflect.full.findAnnotation
 
 context(de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend)
+@Suppress("complexity.TooManyFunctions")
 class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(premise) {
 
     private val defaultFailMessage: String = ""
@@ -81,9 +81,9 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
                         when (location.scope) {
                             Scope.Function -> {
                                 when (location.direction) {
-                                    Direction.afterwards -> TODO()
-                                    Direction.before -> TODO()
-                                    Direction.somewhere -> TODO()
+                                    Direction.Afterwards -> TODO()
+                                    Direction.Before -> TODO()
+                                    Direction.Somewhere -> TODO()
                                 }
                             }
                             Scope.Block -> TODO()

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/evaluators/CpgWheneverEvaluator.kt
@@ -16,59 +16,185 @@
 
 package de.fraunhofer.aisec.codyze.backends.cpg.coko.evaluators
 
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.CpgFinding
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.Nodes
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.dsl.cpgGetNodes
 import de.fraunhofer.aisec.codyze.backends.cpg.coko.modelling.toBackendDataItem
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.EvaluationContext
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.WheneverEvaluator
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.*
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Rule
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.TransformationResult
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
 import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.followNextEOG
+import de.fraunhofer.aisec.cpg.graph.followPrevEOG
+import de.fraunhofer.aisec.cpg.query.executionPath
+import kotlin.reflect.full.findAnnotation
 
 context(de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend)
 class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(premise) {
+
+    private val defaultFailMessage: String = ""
+
+    private val defaultPassMessage: String = ""
     override fun evaluate(context: EvaluationContext): Collection<Finding> {
+        val ruleAnnotation = context.rule.findAnnotation<Rule>()
+        val failMessage = ruleAnnotation?.failMessage?.takeIf { it.isNotEmpty() } ?: defaultFailMessage
+        val passMessage = ruleAnnotation?.passMessage?.takeIf { it.isNotEmpty() } ?: defaultPassMessage
+
+        val findings = mutableListOf<Finding>()
+
         val (premiseNodes, premiseProblems) = evaluateConditionNodeToCpgNodes(premise)
 
+        if (premiseNodes.isEmpty()) {
+            if (premiseProblems.isEmpty()) {
+                findings.add(
+                    CpgFinding(
+                        message = "$premise was not found in code.",
+                        kind = Finding.Kind.NotApplicable,
+                    )
+                )
+            } else {
+                findings.add(
+                    CpgFinding(
+                        message = "$premise could not be resolved correctly. $premiseProblems",
+                        kind = Finding.Kind.Open,
 
-
-
-        TODO("Not yet implemented")
-    }
-
-    private fun evaluateConditionNodeToCpgNodes(conditionNode: ConditionNode): Pair<Nodes, Problems> {
-       return  when (conditionNode) {
-            is ConditionComponent -> evaluateConditionComponentToCpgNodes(conditionNode)
-            is ArgumentItem<*> -> TODO()
-            is ReturnValueItem<*> -> TODO()
-            is Value<*> -> evaluateValue(conditionNode)
+                    )
+                )
+            }
+        } else {
+            for (premiseNode in premiseNodes) {
+                val ensuresToNodes = ensures.associateWith { ensure ->
+                    val (ensureNodes, problems) = evaluateConditionComponentToCpgNodes(ensure, premiseNode)
+                    ensureNodes.filterNot { it is DummyNode } to problems
+                }
+                val callAssertionsToNodes = callAssertions.associateWith { callAssertion ->
+                    val nodes = callAssertion.op.cpgGetNodes()
+                    val location = callAssertion.location
+                    if (location != null) {
+                        when (location.scope) {
+                            Scope.Function -> {
+                                when (location.direction) {
+                                    Direction.afterwards -> TODO()
+                                    Direction.before -> TODO()
+                                    Direction.somewhere -> TODO()
+                                }
+                            }
+                            Scope.Block -> TODO()
+                        }
+                    }
+                    nodes.toList() to Problems()
+                }
+                findings.addAll(
+                    generateFindings(premiseNode, ensuresToNodes + callAssertionsToNodes, passMessage, failMessage)
+                )
+            }
         }
 
+        return findings
     }
 
-    private fun evaluateValue(value: Value<*>): Pair<Nodes, Problems> {
+    private fun generateFindings(
+        premiseNode: Node,
+        conditionToNodes: Map<ConditionComponent, Pair<List<Node>, Problems>>,
+        passMessage: String,
+        failMessage: String
+    ): Collection<Finding> {
+        val findings = mutableListOf<Finding>()
+
+        val unfulfilledConditions = conditionToNodes.filterValues { (nodes, _) -> nodes.isEmpty() }
+
+        if (unfulfilledConditions.isNotEmpty()) {
+            for ((condition, nodesToProblems) in unfulfilledConditions) {
+                val (_, problems) = nodesToProblems
+                if (problems.isEmpty()) {
+                    findings.add(
+                        CpgFinding(
+                            message = "No $condition found around $premise. $failMessage",
+                            kind = Finding.Kind.Fail,
+                            node = premiseNode
+                        )
+                    )
+                    TODO("Better message")
+                } else {
+                    findings.add(
+                        CpgFinding(
+                            message = "There were problems in resolving $condition. $problems",
+                            kind = Finding.Kind.Open,
+                            node = premiseNode,
+                        )
+                    )
+                }
+            }
+        } else {
+            findings.add(
+                CpgFinding(
+                    message = passMessage,
+                    kind = Finding.Kind.Pass,
+                    node = premiseNode,
+                    relatedNodes = conditionToNodes.values.flatMap { it.first }
+                )
+            )
+        }
+
+        return findings
+    }
+
+    private fun evaluateConditionNodeToCpgNodes(
+        conditionNode: ConditionNode,
+        premiseNode: Node? = null
+    ): Pair<Nodes, Problems> {
+        TODO("change to EvaluationResult")
+        return when (conditionNode) {
+            is ConditionComponent -> evaluateConditionComponentToCpgNodes(conditionNode, premiseNode)
+            is ArgumentItem<*> -> evaluateArgumentItemToCpgNodes(conditionNode, premiseNode)
+            is ReturnValueItem<*> -> evaluateReturnValueItemToCpgNodes(conditionNode, premiseNode)
+            is Value<*> -> evaluateValueToCpgNodes(conditionNode, premiseNode)
+        }
+    }
+
+    private fun evaluateValueToCpgNodes(value: Value<*>, premiseNode: Node? = null): Pair<Nodes, Problems> {
         return listOf(DummyNode()) to Problems()
     }
 
-    private fun evaluateConditionComponentToCpgNodes(conditionComponent: ConditionComponent): Pair<Nodes, Problems> {
+    private fun evaluateArgumentItemToCpgNodes(
+        argumentItem: ArgumentItem<*>,
+        premiseNode: Node? = null
+    ): Pair<Nodes, Problems> {
+        val nodes = argumentItem.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
+        return nodes to Problems()
+    }
+
+    private fun evaluateReturnValueItemToCpgNodes(
+        returnValueItem: ReturnValueItem<*>,
+        premiseNode: Node? = null
+    ): Pair<Nodes, Problems> {
+        val nodes = returnValueItem.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
+        return nodes to Problems()
+    }
+
+    private fun evaluateConditionComponentToCpgNodes(
+        conditionComponent: ConditionComponent,
+        premiseNode: Node? = null
+    ): Pair<Nodes, Problems> {
         return when (conditionComponent) {
-            is BinaryLogicalConditionComponent -> evaluateBinaryLogicalConditionComponent(conditionComponent)
-            is ComparisonConditionComponent -> evaluateComparisonConditionComponent(conditionComponent)
+            is BinaryLogicalConditionComponent ->
+                evaluateBinaryLogicalConditionComponent(conditionComponent, premiseNode)
+            is ComparisonConditionComponent -> evaluateComparisonConditionComponent(conditionComponent, premiseNode)
             is UnaryConditionComponent -> TODO()
-            is CallConditionComponent -> evaluateCallConditionComponent(conditionComponent)
-            is ContainsConditionComponent<*, *> -> TODO()
+            is CallConditionComponent -> evaluateCallConditionComponent(conditionComponent, premiseNode)
+            is ContainsConditionComponent<*, *> -> evaluateContainsConditionComponent(conditionComponent, premiseNode)
         }
     }
 
-    private fun evaluateCallConditionComponent(callConditionComponent: CallConditionComponent): Pair<Nodes, Problems> {
-        return callConditionComponent.op.cpgGetNodes() to Problems()
-    }
-
     private fun evaluateBinaryLogicalConditionComponent(
-        binaryLogicalConditionComponent: BinaryLogicalConditionComponent
+        binaryLogicalConditionComponent: BinaryLogicalConditionComponent,
+        premiseNode: Node? = null
     ): Pair<Nodes, Problems> {
-        val (leftNodes, leftProblems) = evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.left)
-        val (rightNodes, rightProblems) = evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.right)
+        val (leftNodes, leftProblems) =
+            evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.left, premiseNode)
+        val (rightNodes, rightProblems) =
+            evaluateConditionComponentToCpgNodes(binaryLogicalConditionComponent.right, premiseNode)
         return when (binaryLogicalConditionComponent.operator) {
             BinaryLogicalOperatorName.AND -> (leftNodes intersect rightNodes) to (leftProblems + rightProblems)
             BinaryLogicalOperatorName.OR -> (leftNodes union rightNodes) to (leftProblems + rightProblems)
@@ -76,50 +202,152 @@ class CpgWheneverEvaluator(premise: ConditionComponent) : WheneverEvaluator(prem
     }
 
     private fun evaluateComparisonConditionComponent(
-        comparisonConditionComponent: ComparisonConditionComponent
+        comparisonConditionComponent: ComparisonConditionComponent,
+        premiseNode: Node? = null
     ): Pair<Nodes, Problems> {
-        val (leftNodes, leftProblems) = evaluateConditionNodeToCpgNodes(comparisonConditionComponent.left)
-        val (rightNodes, rightProblems) = evaluateConditionNodeToCpgNodes(comparisonConditionComponent.right)
+        val (leftNodes, leftProblems) =
+            evaluateConditionNodeToCpgNodes(comparisonConditionComponent.left, premiseNode)
+        val (rightNodes, rightProblems) =
+            evaluateConditionNodeToCpgNodes(comparisonConditionComponent.right, premiseNode)
 
-        val leftNodesToValues = leftNodes.associateWith {
-            comparisonConditionComponent.left.transformation(
-                it.toBackendDataItem()
-            )
-        }
-        val rightNodesToValues = rightNodes.associateWith {
-            comparisonConditionComponent.right.transformation(
-                it.toBackendDataItem()
-            )
+        val newProblems = Problems()
+        val result = mutableSetOf<Node>()
+
+        val leftNodesToValues =
+            leftNodes.toNodesToValues(newProblems, comparisonConditionComponent.left.transformation)
+        val rightNodesToValues =
+            rightNodes.toNodesToValues(newProblems, comparisonConditionComponent.right.transformation)
+
+        for ((leftNode, leftValue) in leftNodesToValues) {
+            for ((rightNode, rightValue) in rightNodesToValues)
+                when (comparisonConditionComponent.operator) {
+                    ComparisonOperatorName.GEQ -> TODO()
+                    ComparisonOperatorName.GT -> TODO()
+                    ComparisonOperatorName.LEQ -> TODO()
+                    ComparisonOperatorName.LT -> TODO()
+                    ComparisonOperatorName.EQ ->
+                        if (leftValue == rightValue) {
+                            result.add(leftNode)
+                            result.add(rightNode)
+                        }
+                    ComparisonOperatorName.NEQ -> TODO()
+                }
         }
 
-        return when (comparisonConditionComponent.operator) {
-            ComparisonOperatorName.GEQ -> TODO()
-            ComparisonOperatorName.GT -> TODO()
-            ComparisonOperatorName.LEQ -> TODO()
-            ComparisonOperatorName.LT -> TODO()
-            ComparisonOperatorName.EQ ->
-                (leftNodesToValues
-                    .filter { (_, value) -> rightNodesToValues.containsValue(value) }
-                    .keys) to (leftProblems + rightProblems)
-            ComparisonOperatorName.NEQ ->
-                (leftNodesToValues
-                    .filterNot { (_, value) -> rightNodesToValues.containsValue(value) }
-                    .keys) to (leftProblems + rightProblems)
+        return result to (leftProblems + rightProblems + newProblems)
+    }
+
+    private fun evaluateCallConditionComponent(
+        callConditionComponent: CallConditionComponent,
+        premiseNode: Node? = null
+    ): Pair<Nodes, Problems> {
+        val callNodes = callConditionComponent.op.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
+        return callNodes to Problems()
+    }
+
+    private fun evaluateContainsConditionComponent(
+        containsConditionComponent: ContainsConditionComponent<*, *>,
+        premiseNode: Node?
+    ): Pair<Nodes, Problems> {
+        val problems = Problems()
+        val nodes = containsConditionComponent.item.cpgGetNodes().filterWithDistanceToPremise(premiseNode)
+        val resultNodes = nodes.filter { node ->
+            val backendDataItem = node.toBackendDataItem()
+            val transformationResult = containsConditionComponent.item.transformation(backendDataItem)
+            if (transformationResult.isFailure) {
+                problems.add(
+                    transformationResult.getFailureReasonOrNull() ?: "Transformation of $backendDataItem failed",
+                    backendDataItem
+                )
+                false
+            } else {
+                val value = transformationResult.getValueOrNull()
+                containsConditionComponent.collection.contains(value)
+            }
+        }
+
+        return resultNodes to Problems()
+    }
+
+    private fun Nodes.toNodesToValues(
+        problems: Problems,
+        transformation: (BackendDataItem) -> TransformationResult<out Any?, String>
+    ): Map<Node, Any> {
+        val result = mutableMapOf<Node, Any>()
+
+        for (node in this) {
+            val backendDataItem = node.toBackendDataItem()
+            val transformationResult = transformation(backendDataItem)
+            val value = transformationResult.getValueOrNull()
+            if (value == null) {
+                problems.add(transformationResult.getFailureReasonOrNull() ?: "Value was null", backendDataItem)
+            } else {
+                result[node] = value
+            }
+        }
+
+        return result
+    }
+
+    private fun Nodes.filterWithDistanceToPremise(premiseNode: Node?): Nodes {
+        return if (premiseNode != null) {
+            this.filter { executionPath(it, premiseNode).value }
+        } else {
+            this
         }
     }
 
-    class Problems {
-        val map: MutableMap<Any, String> = mutableMapOf()
+    private fun Node.eogDistance(other: Node): Int {
+        var to = 0
+        this.followNextEOG {
+            to++
+            it.end == other
+        }
 
-        fun add(reason: String, value: Any) {
+        var from = 0
+        this.followPrevEOG {
+            from++
+            it.end == other
+        }
+
+        return if (to < from) to else from
+    }
+
+    class Problems {
+        private val map: MutableMap<BackendDataItem, String> = mutableMapOf()
+
+        fun add(reason: String, value: BackendDataItem) {
             map[value] = reason
+        }
+
+        fun getProblems(): Map<BackendDataItem, String> = map
+
+        fun isEmpty(): Boolean {
+            return map.isEmpty()
         }
 
         operator fun plus(other: Problems): Problems {
             map.putAll(other.map)
             return this
         }
+
+        override fun toString(): String {
+            return map.toString()
+        }
     }
 
-    class DummyNode: Node()
+    class EvaluationResult() {
+        val fulfillingNodes: MutableList<Node> = mutableListOf()
+        val unfulfillingNodes: MutableList<Node> = mutableListOf()
+        val problems: Problems = Problems()
+
+        constructor(fulfillingNodes: Nodes, unfulfillingNodes: Nodes, problems: Problems): this() {
+            this.fulfillingNodes.addAll(fulfillingNodes)
+            this.unfulfillingNodes.addAll(unfulfillingNodes)
+            this.problems + problems
+        }
+
+    }
+
+    class DummyNode : Node()
 }

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/modelling/CpgBackendDataItem.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/modelling/CpgBackendDataItem.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.fraunhofer.aisec.codyze.backends.cpg.coko.modelling
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.BackendDataItem
+import de.fraunhofer.aisec.cpg.graph.HasType
+import de.fraunhofer.aisec.cpg.graph.Node
+import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
+import de.fraunhofer.aisec.cpg.graph.evaluate
+import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+
+class CpgBackendDataItem(
+    override val name: String?,
+    override val value: Any?,
+    override val type: String?
+) : BackendDataItem
+
+fun Node.toBackendDataItem(): CpgBackendDataItem {
+    val value = (this as? Expression)?.evaluate() ?: (this as? Declaration)?.evaluate()
+    val type = (this as? HasType)?.type?.typeName
+
+    return CpgBackendDataItem(name = name.toString(), value = value, type = type)
+}

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/modelling/CpgBackendDataItem.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/modelling/CpgBackendDataItem.kt
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.backends.cpg.coko.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.BackendDataItem
-import de.fraunhofer.aisec.cpg.graph.HasType
 import de.fraunhofer.aisec.cpg.graph.Node
 import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.evaluate
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
+import de.fraunhofer.aisec.cpg.graph.types.HasType
 
 /** Implementation of the [BackendDataItem] interface for the CPG */
 class CpgBackendDataItem(

--- a/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/modelling/CpgBackendDataItem.kt
+++ b/codyze-backends/cpg/src/main/kotlin/de/fraunhofer/aisec/codyze/backends/cpg/coko/modelling/CpgBackendDataItem.kt
@@ -23,12 +23,14 @@ import de.fraunhofer.aisec.cpg.graph.declarations.Declaration
 import de.fraunhofer.aisec.cpg.graph.evaluate
 import de.fraunhofer.aisec.cpg.graph.statements.expressions.Expression
 
+/** Implementation of the [BackendDataItem] interface for the CPG */
 class CpgBackendDataItem(
     override val name: String?,
     override val value: Any?,
     override val type: String?
 ) : BackendDataItem
 
+/** Returns the [CpgBackendDataItem] of the given [Node] */
 fun Node.toBackendDataItem(): CpgBackendDataItem {
     val value = (this as? Expression)?.evaluate() ?: (this as? Declaration)?.evaluate()
     val type = (this as? HasType)?.type?.typeName

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
@@ -64,6 +64,7 @@ interface CokoBackend : Backend {
     /** Ensures that there are no calls to the [ops] which have arguments that fit the parameters specified in [ops] */
     fun never(vararg ops: Op): Evaluator
 
+    /** Verifies that the [assertionBlock] is ensured when [premise] is found */
     fun whenever(
         premise: Condition.() -> ConditionComponent,
         assertionBlock: WheneverEvaluator.() -> Unit

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
@@ -16,8 +16,10 @@
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core
 
 import de.fraunhofer.aisec.codyze.core.backend.Backend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Condition
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Order
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ConditionComponent
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.OrderToken
 import kotlin.reflect.KFunction
 
@@ -62,5 +64,10 @@ interface CokoBackend : Backend {
     /** Ensures that there are no calls to the [ops] which have arguments that fit the parameters specified in [ops] */
     fun never(vararg ops: Op): Evaluator
 
-    fun whenever(op: Op, assertionBlock: WheneverEvaluator.() -> Unit): Evaluator
+    fun whenever(
+        premise: Condition.() -> ConditionComponent,
+        assertionBlock: WheneverEvaluator.() -> Unit
+    ): WheneverEvaluator
+
+    fun whenever(premise: ConditionComponent, assertionBlock: WheneverEvaluator.() -> Unit): WheneverEvaluator
 }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/CokoBackend.kt
@@ -61,4 +61,6 @@ interface CokoBackend : Backend {
 
     /** Ensures that there are no calls to the [ops] which have arguments that fit the parameters specified in [ops] */
     fun never(vararg ops: Op): Evaluator
+
+    fun whenever(op: Op, assertionBlock: WheneverEvaluator.() -> Unit): Evaluator
 }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
@@ -1,0 +1,30 @@
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core
+
+class WheneverEvaluator {
+    private val ensures: MutableList<Ensure> = mutableListOf()
+
+    fun ensure(block: Ensure.() -> Unit){
+        ensures.add(Ensure().apply(block))
+    }
+
+    internal fun getEnsures(): List<Ensure> = ensures
+
+
+}
+
+class Ensure {
+    val list = SpecialListBuilder()
+
+}
+
+class SpecialList(elements: Collection<Any>): ArrayList<Any>(elements) {
+    override fun contains(element: Any): Boolean {
+        //TODO
+
+        return false
+    }
+}
+
+class SpecialListBuilder {
+    operator fun get(vararg things: Any): SpecialList = SpecialList(things.toList())
+}

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
@@ -18,6 +18,7 @@ package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Condition
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.CallConditionComponent
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ConditionComponent
 
 abstract class WheneverEvaluator(protected val premise: ConditionComponent) : Evaluator {
@@ -46,7 +47,13 @@ class CallLocationBuilder {
 }
 data class CallLocation(val direction: Direction, val scope: Scope)
 
-data class CallAssertion(val op: Op, val location: CallLocation? = null)
+class CallAssertion(op: Op, val location: CallLocation? = null): CallConditionComponent(op) {
+    override fun toString(): String =
+        "Call $op ${
+            if(location != null) "${location.direction} in ${location.scope}."
+            else ""
+        }"
+}
 
 class ListBuilder {
     operator fun <E>get(vararg things: E): List<E> = things.toList()

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
@@ -1,30 +1,53 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core
 
-class WheneverEvaluator {
-    private val ensures: MutableList<Ensure> = mutableListOf()
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Condition
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ConditionComponent
 
-    fun ensure(block: Ensure.() -> Unit){
-        ensures.add(Ensure().apply(block))
+abstract class WheneverEvaluator(protected val premise: ConditionComponent) : Evaluator {
+    protected val ensures: MutableList<ConditionComponent> = mutableListOf()
+    protected val callAssertions: MutableList<CallAssertion> = mutableListOf()
+
+    fun ensure(block: Condition.() -> ConditionComponent) {
+        ensures.add(Condition().run(block))
     }
 
-    internal fun getEnsures(): List<Ensure> = ensures
-
-
-}
-
-class Ensure {
-    val list = SpecialListBuilder()
-
-}
-
-class SpecialList(elements: Collection<Any>): ArrayList<Any>(elements) {
-    override fun contains(element: Any): Boolean {
-        //TODO
-
-        return false
+    fun call(op: Op, location: CallLocationBuilder.() -> CallLocation? = { null }) {
+        callAssertions.add(CallAssertion(op, CallLocationBuilder().run(location)))
     }
 }
 
-class SpecialListBuilder {
-    operator fun get(vararg things: Any): SpecialList = SpecialList(things.toList())
+enum class Direction {
+    afterwards, before, somewhere
+}
+
+enum class Scope {
+    Function, Block
+}
+
+class CallLocationBuilder {
+    infix fun Direction.within(scope: Scope) = CallLocation(this@Direction, scope)
+}
+data class CallLocation(val direction: Direction, val scope: Scope)
+
+data class CallAssertion(val op: Op, val location: CallLocation? = null)
+
+class ListBuilder {
+    operator fun <E>get(vararg things: E): List<E> = things.toList()
 }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/WheneverEvaluator.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Condition
@@ -49,7 +48,7 @@ class CallLocationBuilder {
 data class CallLocation(val direction: Direction, val scope: Scope)
 
 enum class Direction {
-    afterwards, before, somewhere
+    Afterwards, Before, Somewhere
 }
 
 enum class Scope {

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Annotations.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Annotations.kt
@@ -42,8 +42,6 @@ annotation class Rule(
     val precision: Precision = Precision.UNKNOWN,
 )
 
-annotation class RuleSet()
-
 enum class Severity {
     INFO,
     WARNING,

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Annotations.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Annotations.kt
@@ -42,6 +42,8 @@ annotation class Rule(
     val precision: Precision = Precision.UNKNOWN,
 )
 
+annotation class RuleSet()
+
 enum class Severity {
     INFO,
     WARNING,

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
@@ -25,45 +25,51 @@ class Condition {
     val list by lazy { ListBuilder() }
 
     infix fun Any.within(collection: Collection<*>) =
-        ContainsConditionComponent(value(this), collection)
+        ContainsConditionComponent(toValue(this), collection)
 
-    infix fun DataItem.gt(other: DataItem) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.GT)
+    infix fun DataItem<*>.gt(other: DataItem<*>) =
+        ComparisonConditionComponent(this, other, ComparisonOperatorName.GT)
 
-    infix fun Any.gt(other: Any) = value(this) gt value(other)
+    infix fun Any.gt(other: Any) = toValue(this) gt toValue(other)
 
-    infix fun DataItem.geq(other: DataItem) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.GEQ)
+    infix fun DataItem<*>.geq(other: DataItem<*>) =
+        ComparisonConditionComponent(this, other, ComparisonOperatorName.GEQ)
 
-    infix fun Any.geq(other: Any) = value(this) geq value(other)
+    infix fun Any.geq(other: Any) = toValue(this) geq toValue(other)
 
-    infix fun DataItem.lt(other: DataItem) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.LT)
+    infix fun DataItem<*>.lt(other: DataItem<*>) =
+        ComparisonConditionComponent(this, other, ComparisonOperatorName.LT)
 
-    infix fun Any.lt(other: Any) = value(this) lt value(other)
+    infix fun Any.lt(other: Any) = toValue(this) lt toValue(other)
 
-    infix fun DataItem.leq(other: DataItem) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.LEQ)
+    infix fun DataItem<*>.leq(other: DataItem<*>) =
+        ComparisonConditionComponent(this, other, ComparisonOperatorName.LEQ)
 
-    infix fun Any.leq(other: Any) = value(this) leq value(other)
+    infix fun Any.leq(other: Any) = toValue(this) leq toValue(other)
 
-    infix fun DataItem.eq(other: DataItem) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.EQ)
+    infix fun DataItem<*>.eq(other: DataItem<*>) =
+        ComparisonConditionComponent(this, other, ComparisonOperatorName.EQ)
 
-    infix fun Any.eq(other: Any) = value(this) eq value(other)
+    infix fun Any.eq(other: Any) = toValue(this) eq toValue(other)
 
-    infix fun DataItem.neq(other: DataItem) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.NEQ)
+    infix fun DataItem<*>.neq(other: DataItem<*>) =
+        ComparisonConditionComponent(this, other, ComparisonOperatorName.NEQ)
 
-    infix fun Any.neq(other: Any) = value(this) neq value(other)
+    infix fun Any.neq(other: Any) = toValue(this) neq toValue(other)
 
     fun call(op: Op) = CallConditionComponent(op)
 
     infix fun ConditionComponent.and(other: ConditionComponent) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.AND)
+        BinaryLogicalConditionComponent(this, other, BinaryLogicalOperatorName.AND)
 
     infix fun ConditionComponent.or(other: ConditionComponent) =
-        BinaryConditionComponent(this, other, BinaryOperatorName.OR)
+        BinaryLogicalConditionComponent(this, other, BinaryLogicalOperatorName.OR)
 
     fun not(conditionComponent: ConditionComponent) = UnaryConditionComponent(conditionComponent, UnaryOperatorName.NOT)
+
+    private fun toValue(value: Any): DataItem<*> =
+        when(value) {
+            is DataItem<*> -> value
+            else -> Value(value)
+        }
 }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ListBuilder
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
+
+fun condition(block: Condition.() -> ConditionComponent) = Condition().run(block)
+
+class Condition {
+    val list by lazy { ListBuilder() }
+
+    infix fun Any.within(collection: Collection<*>) =
+        ContainsConditionComponent(value(this), collection)
+
+    infix fun DataItem.gt(other: DataItem) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.GT)
+
+    infix fun Any.gt(other: Any) = value(this) gt value(other)
+
+    infix fun DataItem.geq(other: DataItem) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.GEQ)
+
+    infix fun Any.geq(other: Any) = value(this) geq value(other)
+
+    infix fun DataItem.lt(other: DataItem) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.LT)
+
+    infix fun Any.lt(other: Any) = value(this) lt value(other)
+
+    infix fun DataItem.leq(other: DataItem) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.LEQ)
+
+    infix fun Any.leq(other: Any) = value(this) leq value(other)
+
+    infix fun DataItem.eq(other: DataItem) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.EQ)
+
+    infix fun Any.eq(other: Any) = value(this) eq value(other)
+
+    infix fun DataItem.neq(other: DataItem) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.NEQ)
+
+    infix fun Any.neq(other: Any) = value(this) neq value(other)
+
+    fun call(op: Op) = CallConditionComponent(op)
+
+    infix fun ConditionComponent.and(other: ConditionComponent) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.AND)
+
+    infix fun ConditionComponent.or(other: ConditionComponent) =
+        BinaryConditionComponent(this, other, BinaryOperatorName.OR)
+
+    fun not(conditionComponent: ConditionComponent) = UnaryConditionComponent(conditionComponent, UnaryOperatorName.NOT)
+}

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ListBuilder
@@ -22,6 +21,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
 fun condition(block: Condition.() -> ConditionComponent) = Condition().run(block)
 
 /** This class exists to restrict where the functions can be called */
+@Suppress("complexity.TooManyFunctions")
 class Condition {
     /** Can be used to build a list like `list[x,y,z]` */
     val list by lazy { ListBuilder() }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
@@ -68,7 +68,7 @@ class Condition {
     fun not(conditionComponent: ConditionComponent) = UnaryConditionComponent(conditionComponent, UnaryOperatorName.NOT)
 
     private fun toValue(value: Any): DataItem<*> =
-        when(value) {
+        when (value) {
             is DataItem<*> -> value
             else -> Value(value)
         }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Condition.kt
@@ -21,50 +21,123 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
 
 fun condition(block: Condition.() -> ConditionComponent) = Condition().run(block)
 
+/** This class exists to restrict where the functions can be called */
 class Condition {
+    /** Can be used to build a list like `list[x,y,z]` */
     val list by lazy { ListBuilder() }
 
-    infix fun Any.within(collection: Collection<*>) =
-        ContainsConditionComponent(toValue(this), collection)
+    /**
+     * Builds a [ContainsConditionComponent] that specifies that the value of this [DataItem] should be
+     * contained in [collection].
+     */
+    infix fun DataItem<*>.within(collection: Collection<*>) =
+        ContainsConditionComponent(this, collection)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this [DataItem] should be
+     * greater than the value of [other].
+     */
     infix fun DataItem<*>.gt(other: DataItem<*>) =
         ComparisonConditionComponent(this, other, ComparisonOperatorName.GT)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this should be
+     * greater than the value of [other].
+     */
+    // This function exists so users don't have to wrap the objects as Value themselves
     infix fun Any.gt(other: Any) = toValue(this) gt toValue(other)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this [DataItem] should be
+     * greater or equal to the value of [other].
+     */
     infix fun DataItem<*>.geq(other: DataItem<*>) =
         ComparisonConditionComponent(this, other, ComparisonOperatorName.GEQ)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this should be
+     * greater or equal to the value of [other].
+     */
+    // This function exists so users don't have to wrap the objects as Value themselves
     infix fun Any.geq(other: Any) = toValue(this) geq toValue(other)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this [DataItem] should be
+     * less than the value of [other].
+     */
     infix fun DataItem<*>.lt(other: DataItem<*>) =
         ComparisonConditionComponent(this, other, ComparisonOperatorName.LT)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this should be
+     * less than the value of [other].
+     */
+    // This function exists so users don't have to wrap the objects as Value themselves
     infix fun Any.lt(other: Any) = toValue(this) lt toValue(other)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this [DataItem] should be
+     * less or equal to the value of [other].
+     */
     infix fun DataItem<*>.leq(other: DataItem<*>) =
         ComparisonConditionComponent(this, other, ComparisonOperatorName.LEQ)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this should be
+     * less or equal to the value of [other].
+     */
+    // This function exists so users don't have to wrap the objects as Value themselves
     infix fun Any.leq(other: Any) = toValue(this) leq toValue(other)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this [DataItem] should be
+     * equal to the value of [other].
+     */
     infix fun DataItem<*>.eq(other: DataItem<*>) =
         ComparisonConditionComponent(this, other, ComparisonOperatorName.EQ)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this should be
+     * equal to the value of [other].
+     */
+    // This function exists so users don't have to wrap the objects as Value themselves
     infix fun Any.eq(other: Any) = toValue(this) eq toValue(other)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this [DataItem] should not be
+     * equal to the value of [other].
+     */
     infix fun DataItem<*>.neq(other: DataItem<*>) =
         ComparisonConditionComponent(this, other, ComparisonOperatorName.NEQ)
 
+    /**
+     * Builds a [ComparisonConditionComponent] that specifies that the value of this should not be
+     * equal to the value of [other].
+     */
+    // This function exists so users don't have to wrap the objects as Value themselves
     infix fun Any.neq(other: Any) = toValue(this) neq toValue(other)
 
+    /**
+     * Builds a [CallConditionComponent] that specifies that [op] should be called.
+     */
+    // TODO: Is this needed?
     fun call(op: Op) = CallConditionComponent(op)
 
+    /**
+     * Connects two [ConditionComponent]s with a logical and.
+     */
     infix fun ConditionComponent.and(other: ConditionComponent) =
         BinaryLogicalConditionComponent(this, other, BinaryLogicalOperatorName.AND)
 
+    /**
+     * Connects two [ConditionComponent]s with a logical or.
+     */
     infix fun ConditionComponent.or(other: ConditionComponent) =
         BinaryLogicalConditionComponent(this, other, BinaryLogicalOperatorName.OR)
 
+    /**
+     * Negates a [ConditionComponent]
+     */
     fun not(conditionComponent: ConditionComponent) = UnaryConditionComponent(conditionComponent, UnaryOperatorName.NOT)
 
     private fun toValue(value: Any): DataItem<*> =

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -110,7 +110,8 @@ class ConstructorOp internal constructor(
     }
 }
 
-data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = ""): Op
+/** An [Op] that contains other [Op]s */
+data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = "") : Op
 
 context(Any) // This is needed to have access to the owner of this function
 // -> in which class is the function defined that created this [OP]

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -124,6 +124,15 @@ data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = "")
     }
 }
 
+/**
+ * An [Op] that describes that the function calls found with [resultOp] depend on the function calls found with the [conditionOp]
+ */
+data class ConditionalOp(val resultOp: Op, val conditionOp: Op, override val ownerClassFqn: String = "") : Op {
+    override fun toString(): String {
+        return "$resultOp with $conditionOp"
+    }
+}
+
 context(Any) // This is needed to have access to the owner of this function
 // -> in which class is the function defined that created this [OP]
 /**
@@ -173,8 +182,15 @@ fun constructor(classFqn: String, block: ConstructorOp.() -> Unit): ConstructorO
     return ConstructorOp(classFqn, this@Any::class.java.name).apply(block)
 }
 
+/** Create a [GroupingOp] containing the given [ops]. */
 context(Any)
 fun opGroup(vararg ops: Op): GroupingOp = GroupingOp(ops.toSet(), this@Any::class.java.name)
+
+/**
+ * Create a [ConditionalOp] with [this] as the [ConditionalOp.resultOp] and [conditionOp] as the [ConditionalOp.conditionOp]
+ */
+context(Any)
+infix fun Op.with(conditionOp: Op): ConditionalOp = ConditionalOp(this, conditionOp, this@Any::class.java.name)
 
 /**
  * Create a [Definition] which can be added to the [FunctionOp].

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -110,6 +110,8 @@ class ConstructorOp internal constructor(
     }
 }
 
+data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = ""): Op
+
 context(Any) // This is needed to have access to the owner of this function
 // -> in which class is the function defined that created this [OP]
 /**
@@ -158,6 +160,9 @@ context(Any) // This is needed to have access to the owner of this function
 fun constructor(classFqn: String, block: ConstructorOp.() -> Unit): ConstructorOp {
     return ConstructorOp(classFqn, this@Any::class.java.name).apply(block)
 }
+
+context(Any)
+fun opGroup(vararg ops: Op): GroupingOp = GroupingOp(ops.toSet(), this@Any::class.java.name)
 
 /**
  * Create a [Definition] which can be added to the [FunctionOp].

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("TooManyFunctions")
+
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoMarker

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -20,7 +20,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.OrderFragment
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.TerminalOrderNode
 
-@CokoMarker sealed interface Op : OrderFragment, ConditionComponent {
+@CokoMarker sealed interface Op : OrderFragment {
     val ownerClassFqn: String
 
     val returnValue: ReturnValueItem<Any>

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -35,6 +35,9 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.Term
     )
 }
 
+/**
+ * A helper class that makes it possible to construct an [ArgumentItem] with an indexed access (e.g. op.argument[1])
+ */
 class Arguments(val op: Op) {
     operator fun get(index: Int): ArgumentItem<Any> = ArgumentItem(op, index)
 }
@@ -127,6 +130,7 @@ data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = "")
 /**
  * An [Op] that describes that the function calls found with [resultOp] depend on the function calls found with the [conditionOp]
  */
+// TODO: Clearly define the dependency we are describing here -> is it data flow, control flow, or something else?
 data class ConditionalOp(val resultOp: Op, val conditionOp: Op, override val ownerClassFqn: String = "") : Op {
     override fun toString(): String {
         return "$resultOp with $conditionOp"

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/Op.kt
@@ -16,20 +16,27 @@
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoMarker
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Definition
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Parameter
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.ParameterGroup
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.Signature
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.*
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.OrderFragment
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.ordering.TerminalOrderNode
 
-@CokoMarker sealed interface Op : OrderFragment {
+@CokoMarker sealed interface Op : OrderFragment, ConditionComponent {
     val ownerClassFqn: String
+
+    val returnValue: ReturnValueItem<Any>
+        get() = ReturnValueItem(this)
+
+    val arguments: Arguments
+        get() = Arguments(this)
 
     override fun toNode(): TerminalOrderNode = TerminalOrderNode(
         baseName = ownerClassFqn,
         opName = hashCode().toString()
     )
+}
+
+class Arguments(val op: Op) {
+    operator fun get(index: Int): ArgumentItem<Any> = ArgumentItem(op, index)
 }
 
 /**
@@ -111,7 +118,11 @@ class ConstructorOp internal constructor(
 }
 
 /** An [Op] that contains other [Op]s */
-data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = "") : Op
+data class GroupingOp(val ops: Set<Op>, override val ownerClassFqn: String = "") : Op {
+    override fun toString(): String {
+        return ops.joinToString()
+    }
+}
 
 context(Any) // This is needed to have access to the owner of this function
 // -> in which class is the function defined that created this [OP]

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
+
+sealed interface TransformationResult<E> {
+    val isFailure: Boolean
+    val isSuccess: Boolean
+
+    fun getValueOrNull(): E?
+    fun getMessageOrNull(): String?
+    override fun toString(): String
+
+    companion object {
+        fun <E> failure(message: String): TransformationResult<E> = TransformationFailure(message)
+
+        fun <E> success(value: E): TransformationResult<E> = TransformationSuccess(value)
+    }
+}
+
+private data class TransformationSuccess<E>(val value: E) : TransformationResult<E> {
+    override val isFailure: Boolean
+        get() = false
+    override val isSuccess: Boolean
+        get() = true
+
+    override fun getValueOrNull(): E? = value
+
+    override fun getMessageOrNull(): String? = null
+}
+
+private data class TransformationFailure<E>(val message: String) : TransformationResult<E> {
+    override val isFailure: Boolean
+        get() = true
+    override val isSuccess: Boolean
+        get() = false
+
+    override fun getValueOrNull(): E? = null
+
+    override fun getMessageOrNull(): String = message
+}

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
 
 /**

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
@@ -16,22 +16,32 @@
 
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl
 
-sealed interface TransformationResult<E> {
+/**
+ * This class works similar to the [Result] class in the Kotlin standard library.
+ * The difference is that the [TransformationFailure] can store information other than [Throwable]s to be able to
+ * describe the reasons for failure in more detail.
+ */
+sealed interface TransformationResult<E, T> {
     val isFailure: Boolean
     val isSuccess: Boolean
 
     fun getValueOrNull(): E?
-    fun getMessageOrNull(): String?
+    fun getFailureReasonOrNull(): T?
     override fun toString(): String
 
     companion object {
-        fun <E> failure(message: String): TransformationResult<E> = TransformationFailure(message)
+        /** Creates a [TransformationFailure] object with the given [reason]. */
+        fun <E,T> failure(reason: T): TransformationResult<E, T> = TransformationFailure(reason)
 
-        fun <E> success(value: E): TransformationResult<E> = TransformationSuccess(value)
+        /** Creates a [TransformationSuccess] object with the given [value]. */
+        fun <E,T> success(value: E): TransformationResult<E,T> = TransformationSuccess(value)
     }
 }
 
-private data class TransformationSuccess<E>(val value: E) : TransformationResult<E> {
+/**
+ * This class indicates that the operation was a success and the result is stored in [value].
+ */
+private data class TransformationSuccess<E,T>(val value: E) : TransformationResult<E,T> {
     override val isFailure: Boolean
         get() = false
     override val isSuccess: Boolean
@@ -39,10 +49,13 @@ private data class TransformationSuccess<E>(val value: E) : TransformationResult
 
     override fun getValueOrNull(): E? = value
 
-    override fun getMessageOrNull(): String? = null
+    override fun getFailureReasonOrNull(): T? = null
 }
 
-private data class TransformationFailure<E>(val message: String) : TransformationResult<E> {
+/**
+ * This class indicates that the operation was not successful and the reasons are stored in [reason].
+ */
+private data class TransformationFailure<E, T>(val reason: T) : TransformationResult<E,T> {
     override val isFailure: Boolean
         get() = true
     override val isSuccess: Boolean
@@ -50,5 +63,5 @@ private data class TransformationFailure<E>(val message: String) : Transformatio
 
     override fun getValueOrNull(): E? = null
 
-    override fun getMessageOrNull(): String = message
+    override fun getFailureReasonOrNull(): T = reason
 }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/dsl/TransformationResult.kt
@@ -31,17 +31,17 @@ sealed interface TransformationResult<E, T> {
 
     companion object {
         /** Creates a [TransformationFailure] object with the given [reason]. */
-        fun <E,T> failure(reason: T): TransformationResult<E, T> = TransformationFailure(reason)
+        fun <E, T> failure(reason: T): TransformationResult<E, T> = TransformationFailure(reason)
 
         /** Creates a [TransformationSuccess] object with the given [value]. */
-        fun <E,T> success(value: E): TransformationResult<E,T> = TransformationSuccess(value)
+        fun <E, T> success(value: E): TransformationResult<E, T> = TransformationSuccess(value)
     }
 }
 
 /**
  * This class indicates that the operation was a success and the result is stored in [value].
  */
-private data class TransformationSuccess<E,T>(val value: E) : TransformationResult<E,T> {
+private data class TransformationSuccess<E, T>(val value: E) : TransformationResult<E, T> {
     override val isFailure: Boolean
         get() = false
     override val isSuccess: Boolean
@@ -55,7 +55,7 @@ private data class TransformationSuccess<E,T>(val value: E) : TransformationResu
 /**
  * This class indicates that the operation was not successful and the reasons are stored in [reason].
  */
-private data class TransformationFailure<E, T>(val reason: T) : TransformationResult<E,T> {
+private data class TransformationFailure<E, T>(val reason: T) : TransformationResult<E, T> {
     override val isFailure: Boolean
         get() = true
     override val isSuccess: Boolean

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/BackendDataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/BackendDataItem.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
+
+/**
+ * Interface for accessing info about a DataItem from the [CokoBackend]
+ */
+interface BackendDataItem {
+    val name: String?
+    val value: Any?
+    val type: String?
+}

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/BackendDataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/BackendDataItem.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
@@ -18,7 +18,9 @@ package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 
-sealed interface ConditionNode
+sealed interface ConditionNode {
+    override fun toString(): String
+}
 sealed interface ConditionComponent : ConditionNode
 sealed interface ConditionLeaf : ConditionNode
 
@@ -32,22 +34,32 @@ class ComparisonConditionComponent(
     override val left: DataItem<*>,
     override val right: DataItem<*>,
     override val operator: ComparisonOperatorName
-) : BinaryConditionComponent
+) : BinaryConditionComponent {
+    override fun toString(): String = "$left ${operator.name} $right"
+}
 
 class BinaryLogicalConditionComponent(
     override val left: ConditionComponent,
     override val right: ConditionComponent,
     override val operator: BinaryLogicalOperatorName
-) : BinaryConditionComponent
+) : BinaryConditionComponent {
+    override fun toString(): String = "$left ${operator.name} $right"
+}
 
 class UnaryConditionComponent(
     val conditionNode: ConditionNode,
     val operator: UnaryOperatorName
-) : ConditionComponent
+) : ConditionComponent {
+    override fun toString(): String = "${operator.name} $conditionNode"
+}
 
-class CallConditionComponent(val op: Op) : ConditionComponent
+open class CallConditionComponent(val op: Op) : ConditionComponent {
+    override fun toString(): String = op.toString()
+}
 
-class ContainsConditionComponent<E, T>(val item: DataItem<E>, val collection: Collection<T>) : ConditionComponent
+class ContainsConditionComponent<E, T>(val item: DataItem<E>, val collection: Collection<T>) : ConditionComponent {
+    override fun toString(): String = "$item within $collection"
+}
 
 sealed interface BinaryOperatorName {
     val operatorCodes: List<String>

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
+
+interface ConditionComponent
+
+class BinaryConditionComponent(
+    val left: ConditionComponent,
+    val right: ConditionComponent,
+    val operator: BinaryOperatorName
+) : ConditionComponent
+
+class UnaryConditionComponent(
+    val conditionComponent: ConditionComponent,
+    val operator: UnaryOperatorName
+) : ConditionComponent
+
+class CallConditionComponent(val op: Op) : ConditionComponent
+
+class ContainsConditionComponent<E>(val item: DataItem, val collection: Collection<E>) : ConditionComponent
+
+enum class BinaryOperatorName(val operatorCodes: List<String>) {
+    GEQ(listOf(">=")),
+    GT(listOf(">")),
+    LEQ(listOf("<=")),
+    LT(listOf("<")),
+    EQ(listOf("==")), // TODO: python `==` vs `is`
+    NEQ(listOf("!=")),
+    AND(listOf("&&", "and")),
+    OR(listOf("||", "or"))
+}
+
+enum class UnaryOperatorName(val operatorCodes: List<String>) {
+    NOT(listOf("!", "not"))
+}
+
+// idea:
+// isChecked(doStuff(Wildcard).returnValue) {
+//      (it lessThan 0) or (it greaterThan 1)
+// }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
@@ -21,15 +21,21 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 sealed interface ConditionNode {
     override fun toString(): String
 }
+
+/** [ConditionNode] that can have children */
 sealed interface ConditionComponent : ConditionNode
+
+/** [ConditionNode] that does not have children */
 sealed interface ConditionLeaf : ConditionNode
 
+/** A [ConditionComponent] that has two children and a [operator] */
 sealed interface BinaryConditionComponent : ConditionComponent {
     val left: ConditionNode
     val right: ConditionNode
     val operator: BinaryOperatorName
 }
 
+/** A [BinaryConditionComponent] that compares [left] and [right] based on [operator] (e.g. equality or less than) */
 class ComparisonConditionComponent(
     override val left: DataItem<*>,
     override val right: DataItem<*>,
@@ -38,6 +44,7 @@ class ComparisonConditionComponent(
     override fun toString(): String = "$left ${operator.name} $right"
 }
 
+/** A [BinaryConditionComponent] that logically combines [left] and [right] based on [operator] (e.g. logical and) */
 class BinaryLogicalConditionComponent(
     override val left: ConditionComponent,
     override val right: ConditionComponent,
@@ -46,6 +53,7 @@ class BinaryLogicalConditionComponent(
     override fun toString(): String = "$left ${operator.name} $right"
 }
 
+/** A [ConditionComponent] that has one child, [conditionNode], and a [operator] (e.g. negation) */
 class UnaryConditionComponent(
     val conditionNode: ConditionNode,
     val operator: UnaryOperatorName
@@ -53,10 +61,13 @@ class UnaryConditionComponent(
     override fun toString(): String = "${operator.name} $conditionNode"
 }
 
+/** A [ConditionComponent] that represents a function call */
+// TODO: Is this necessary? And should it be a ConditionLeaf?
 open class CallConditionComponent(val op: Op) : ConditionComponent {
     override fun toString(): String = op.toString()
 }
 
+/** A [ConditionComponent] that represents the condition that the value of [item] should be in [collection] */
 class ContainsConditionComponent<E, T>(val item: DataItem<E>, val collection: Collection<T>) : ConditionComponent {
     override fun toString(): String = "$item within $collection"
 }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
@@ -18,39 +18,54 @@ package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 
-interface ConditionComponent
+sealed interface ConditionNode
+sealed interface ConditionComponent : ConditionNode
+sealed interface ConditionLeaf : ConditionNode
 
-class BinaryConditionComponent(
-    val left: ConditionComponent,
-    val right: ConditionComponent,
+sealed interface BinaryConditionComponent : ConditionComponent {
+    val left: ConditionNode
+    val right: ConditionNode
     val operator: BinaryOperatorName
-) : ConditionComponent
+}
+
+class ComparisonConditionComponent(
+    override val left: DataItem<*>,
+    override val right: DataItem<*>,
+    override val operator: ComparisonOperatorName
+) : BinaryConditionComponent
+
+class BinaryLogicalConditionComponent(
+    override val left: ConditionComponent,
+    override val right: ConditionComponent,
+    override val operator: BinaryLogicalOperatorName
+) : BinaryConditionComponent
 
 class UnaryConditionComponent(
-    val conditionComponent: ConditionComponent,
+    val conditionNode: ConditionNode,
     val operator: UnaryOperatorName
 ) : ConditionComponent
 
 class CallConditionComponent(val op: Op) : ConditionComponent
 
-class ContainsConditionComponent<E>(val item: DataItem, val collection: Collection<E>) : ConditionComponent
+class ContainsConditionComponent<E, T>(val item: DataItem<E>, val collection: Collection<T>) : ConditionComponent
 
-enum class BinaryOperatorName(val operatorCodes: List<String>) {
+sealed interface BinaryOperatorName {
+    val operatorCodes: List<String>
+}
+
+enum class BinaryLogicalOperatorName(override val operatorCodes: List<String>) : BinaryOperatorName {
+    AND(listOf("&&", "and")),
+    OR(listOf("||", "or"))
+}
+enum class ComparisonOperatorName(override val operatorCodes: List<String>) : BinaryOperatorName {
     GEQ(listOf(">=")),
     GT(listOf(">")),
     LEQ(listOf("<=")),
     LT(listOf("<")),
     EQ(listOf("==")), // TODO: python `==` vs `is`
     NEQ(listOf("!=")),
-    AND(listOf("&&", "and")),
-    OR(listOf("||", "or"))
 }
 
 enum class UnaryOperatorName(val operatorCodes: List<String>) {
     NOT(listOf("!", "not"))
 }
-
-// idea:
-// isChecked(doStuff(Wildcard).returnValue) {
-//      (it lessThan 0) or (it greaterThan 1)
-// }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/ConditionComponents.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
@@ -19,16 +19,30 @@ package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.TransformationResult
 
+/**
+ * Represents a data item such as a variable or literal.
+ *
+ * [transformation] is a function that transforms data from the [CokoBackend] into an object with type [E]
+ */
 sealed interface DataItem<E> : ConditionLeaf {
     val transformation: (BackendDataItem) -> TransformationResult<E, String>
 }
 
+/**
+ * Adds an infix function [withTransformation] to a [DataItem].
+ */
 sealed interface CanChangeTransformation<E> : DataItem<E> {
+    /**
+     * Changes the [transformation] of this [DataItem] into the given [newTransformation].
+     */
     infix fun <T> withTransformation(
         newTransformation: (BackendDataItem) -> TransformationResult<T, String>
     ): DataItem<T>
 }
 
+/**
+ * Represents the data item that a function call represented by [op] returns.
+ */
 data class ReturnValueItem<E>(
     val op: Op,
     override val transformation: (BackendDataItem) -> TransformationResult<E, String> = {
@@ -43,6 +57,11 @@ data class ReturnValueItem<E>(
         ReturnValueItem(op = op, transformation = newTransformation)
 }
 
+/**
+ * Represents the argument at [index] given to the function call represented by [op].
+ *
+ * The [index] starts counting from 0.
+ */
 data class ArgumentItem<E>(
     val op: Op,
     val index: Int,
@@ -74,6 +93,9 @@ data class ArgumentItem<E>(
     }
 }
 
+/**
+ * A wrapper class for [value] to make it a [DataItem].
+ */
 data class Value<E> internal constructor(val value: E) : DataItem<E> {
     override val transformation: (BackendDataItem) -> TransformationResult<E, String>
         get() = { TransformationResult.success(value) }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
@@ -1,0 +1,12 @@
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
+
+sealed interface DataItem
+
+data class ReturnValueItem(val op: Op) : DataItem {
+    override fun toString(): String = "Return value of $op"
+}
+
+data class Value(val value: Any) : DataItem
+

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
@@ -1,12 +1,81 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.TransformationResult
 
-sealed interface DataItem
+sealed interface DataItem : ConditionComponent
 
-data class ReturnValueItem(val op: Op) : DataItem {
-    override fun toString(): String = "Return value of $op"
+sealed interface HasTransformation<E> : DataItem {
+    val transformation: (BackendDataItem) -> TransformationResult<E>
+    infix fun <T> withTransformation(
+        newTransformation: (BackendDataItem) -> TransformationResult<T>
+    ): HasTransformation<T>
 }
 
-data class Value(val value: Any) : DataItem
+data class ReturnValueItem<E>(
+    val op: Op,
+    override val transformation: (BackendDataItem) -> TransformationResult<E> = {
+        TransformationResult.failure("No transformation given from user")
+    }
+) : HasTransformation<E> {
+    override fun toString(): String = "Return value of $op"
 
+    override infix fun <T> withTransformation(
+        newTransformation: (BackendDataItem) -> TransformationResult<T>
+    ): ReturnValueItem<T> =
+        ReturnValueItem(op = op, transformation = newTransformation)
+}
+
+data class ArgumentItem<E>(
+    val op: Op,
+    val number: Int,
+    override val transformation: (BackendDataItem) -> TransformationResult<E> = {
+        TransformationResult.failure("No transformation given from user")
+    }
+) : HasTransformation<E> {
+    init {
+        require(number >= 0) { "The number of the argument cannot be negative" }
+    }
+
+    override fun <T> withTransformation(
+        newTransformation: (BackendDataItem) -> TransformationResult<T>
+    ): ArgumentItem<T> =
+        ArgumentItem(op = op, number = number, transformation = newTransformation)
+
+    override fun toString(): String = "${number.ordinal()} argument of $op"
+
+    @Suppress("MagicNumber")
+    fun Int.ordinal(): String {
+        return "$this" + when {
+            (this % 100 in 11..13) -> "th"
+            (this % 10) == 1 -> "st"
+            (this % 10) == 2 -> "nd"
+            (this % 10) == 3 -> "rd"
+            else -> "th"
+        }
+    }
+}
+
+data class Value internal constructor(val value: Any) : DataItem
+
+fun value(value: Any): DataItem =
+    when (value) {
+        is DataItem -> value
+        else -> Value(value)
+    }

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
@@ -45,21 +45,22 @@ data class ReturnValueItem<E>(
 
 data class ArgumentItem<E>(
     val op: Op,
-    val number: Int,
+    val index: Int,
     override val transformation: (BackendDataItem) -> TransformationResult<E, String> = {
         TransformationResult.failure("No transformation given from user")
     }
 ) : CanChangeTransformation<E> {
     init {
-        require(number >= 0) { "The number of the argument cannot be negative" }
+        // TODO: Do we count starting at 0 or 1?
+        require(index >= 0) { "The number of the argument cannot be negative" }
     }
 
     override fun <T> withTransformation(
         newTransformation: (BackendDataItem) -> TransformationResult<T, String>
     ): ArgumentItem<T> =
-        ArgumentItem(op = op, number = number, transformation = newTransformation)
+        ArgumentItem(op = op, index = index, transformation = newTransformation)
 
-    override fun toString(): String = "${number.ordinal()} argument of $op"
+    override fun toString(): String = "${(index + 1).ordinal()} argument of $op"
 
     @Suppress("MagicNumber")
     fun Int.ordinal(): String {

--- a/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
+++ b/codyze-specification-languages/coko/coko-core/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/core/modelling/DataItem.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Op

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
@@ -16,7 +16,6 @@
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Import
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import kotlin.script.experimental.annotations.KotlinScript

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
@@ -21,8 +21,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.*
-import kotlin.script.experimental.host.FileBasedScriptSource
-import kotlin.script.experimental.host.FileScriptSource
 import kotlin.script.experimental.jvm.*
 import kotlin.script.experimental.jvm.util.scriptCompilationClasspathFromContext
 
@@ -61,6 +59,7 @@ interface PluginDependenciesSpec {
 
 internal object ProjectScriptCompilationConfiguration :
     ScriptCompilationConfiguration({
+
         baseClass(CokoScript::class)
         jvm {
             dependenciesFromClassContext( // extract dependencies from the host environment
@@ -109,12 +108,6 @@ internal object ProjectScriptCompilationConfiguration :
                     context.compilationConfiguration.asSuccess()
                 }
             }
-
-            // the callback called than any of the listed file-level annotations are encountered in
-            // the compiled script
-            // the processing is defined by the `handler`, that may return refined configuration
-            // depending on the annotations
-            onAnnotations(Import::class, handler = ::configureImportDepsOnAnnotations)
         }
 
         ide { acceptedLocations(ScriptAcceptedLocation.Everywhere) }
@@ -146,29 +139,7 @@ private fun resolveClasspathAndGenerateExtensionsFor(pluginsBlock: String?): Lis
     )
 }
 
-// The handler that is called during script compilation in order to reconfigure compilation on the
-// fly
-fun configureImportDepsOnAnnotations(
-    context: ScriptConfigurationRefinementContext
-): ResultWithDiagnostics<ScriptCompilationConfiguration> {
-    val annotations =
-        // If no action is performed, the original configuration should be returned
-        context.collectedData?.get(ScriptCollectedData.foundAnnotations)?.takeIf { it.isNotEmpty() }
-            ?: return context.compilationConfiguration.asSuccess()
 
-    val scriptBaseDir = (context.script as? FileBasedScriptSource)?.file?.parentFile
-    val importedSources =
-        annotations.flatMap {
-            (it as? Import)?.paths?.map { sourceName ->
-                FileScriptSource(scriptBaseDir?.resolve(sourceName) ?: File(sourceName))
-            }.orEmpty()
-        }
-
-    return ScriptCompilationConfiguration(context.compilationConfiguration) {
-        if (importedSources.isNotEmpty()) importScripts.append(importedSources)
-    }
-        .asSuccess()
-}
 
 object ProjectScriptEvaluationConfiguration :
     ScriptEvaluationConfiguration({

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScript.kt
@@ -139,8 +139,6 @@ private fun resolveClasspathAndGenerateExtensionsFor(pluginsBlock: String?): Lis
     )
 }
 
-
-
 object ProjectScriptEvaluationConfiguration :
     ScriptEvaluationConfiguration({
         // if a script is imported multiple times in the import hierarchy, use a single copy

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/cli/Validation.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/cli/Validation.kt
@@ -24,7 +24,7 @@ val Path.fileNameString: String
 fun validateSpec(spec: List<Path>): List<Path> {
     require(spec.all { it.isRegularFile() }) { "All given spec paths must be files." }
     require(spec.all { it.fileNameString.endsWith(".codyze.kts") || it.fileNameString.endsWith(".concepts") }) {
-        "All given specification files must be coko specification files (*.codyze.kts)."
+        "All given specification files must be coko specification files (*.codyze.kts) or concept files (*.concepts)."
     }
     return spec
 }

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/cli/Validation.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/cli/Validation.kt
@@ -23,7 +23,7 @@ val Path.fileNameString: String
 
 fun validateSpec(spec: List<Path>): List<Path> {
     require(spec.all { it.isRegularFile() }) { "All given spec paths must be files." }
-    require(spec.all { it.fileNameString.endsWith(".codyze.kts") }) {
+    require(spec.all { it.fileNameString.endsWith(".codyze.kts") || it.fileNameString.endsWith(".concepts") }) {
         "All given specification files must be coko specification files (*.codyze.kts)."
     }
     return spec

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
@@ -32,7 +32,6 @@ import kotlin.script.experimental.api.*
 import kotlin.script.experimental.api.SourceCode
 import kotlin.script.experimental.host.FileBasedScriptSource
 import kotlin.script.experimental.host.FileScriptSource
-import kotlin.script.experimental.host.StringScriptSource
 import kotlin.script.experimental.host.toScriptSource
 import kotlin.script.experimental.jvm.baseClassLoader
 import kotlin.script.experimental.jvm.jvm
@@ -100,7 +99,7 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             baseClassLoader: ClassLoader? = null
         ): ResultWithDiagnostics<EvaluationResult> {
             val compilationConfiguration =
-                createJvmCompilationConfigurationFromTemplate<CokoScript>() {
+                createJvmCompilationConfigurationFromTemplate<CokoScript> {
                     refineConfiguration {
                         // the callback called if any of the listed file-level annotations are encountered in
                         // the compiled script
@@ -108,7 +107,6 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
                         // depending on the annotations
                         onAnnotations(Import::class, handler = ::configureImportDepsOnAnnotations)
                     }
-
                 }
             val evaluationConfiguration =
                 createJvmEvaluationConfigurationFromTemplate<CokoScript> {
@@ -227,12 +225,13 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
 
                     (it as? Import)?.paths?.mapNotNull { sourceName ->
                         val file = scriptBaseDir?.resolve(sourceName) ?: File(sourceName).normalize()
-                        val absoluteFile = file.absolutePath
-                        if(sourceName.endsWith(".codyze.kts"))
+                        if (sourceName.endsWith(".codyze.kts")) {
                             FileScriptSource(file)
-                        else if (sourceName.endsWith(".concepts"))
+                        } else if (sourceName.endsWith(".concepts")) {
                             conceptTranslator.transformConceptFile(file.toPath())
-                        else null
+                        } else {
+                            null
+                        }
                     }.orEmpty()
                 }
 
@@ -241,8 +240,5 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             }
                 .asSuccess()
         }
-
     }
-
-
 }

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
@@ -19,6 +19,7 @@ import de.fraunhofer.aisec.codyze.core.executor.Executor
 import de.fraunhofer.aisec.codyze.core.timed
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.GroupingOp
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoConfiguration
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoSarifBuilder
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoScript
@@ -132,9 +133,9 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             for (specFile in specFiles) {
                 val scriptSource = if (specFile.extension == "concepts") {
                     transformConceptFile(specFile)
-                } else
+                } else {
                     FileScriptSource(specFile.toFile())
-
+                }
 
                 // compile the script
                 val result =
@@ -194,69 +195,17 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             return specEvaluator
         }
 
-        fun transformConceptFile(specFile: Path): StringScriptSource {
+        private fun transformConceptFile(specFile: Path): StringScriptSource {
             val fileScriptSource = FileScriptSource(specFile.toFile())
 
             val fileText = fileScriptSource.text
             val preliminaryScriptText = fileText
                 // Remove all comments
-                // TODO: is there a better way?
+                // TODO: Is there a way to specify that all Regexes should not include matches found in comments?
                 .replace(Regex("//.*\\n"), "\n")
                 // Handle all `op` keywords that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
                 .replace(Regex("\\s+op\\s+.+=.+\\s")) { opPointerMatchResult ->
-                    val preliminaryResult = opPointerMatchResult.value
-                        // remove the whitespace character at the end of the matchResult
-                        .dropLast(1)
-                        // Replace all `op` keywords with `fun`
-                        .replace("op", "fun")
-
-                    // The index of the '{' character that starts the body of the concept that the "op" resides in
-                    val conceptBodyStart = fileText.lastIndexOf('{', opPointerMatchResult.range.first)
-                    // The index of the '}' character that ends the body of the concept that the "op" resides in
-                    val conceptBodyEnd = fileText.indexOf('}', opPointerMatchResult.range.last)
-
-                    val conceptBody = fileText.subSequence(conceptBodyStart, conceptBodyEnd)
-
-                    val (firstHalf, secondHalf) = preliminaryResult.split(Regex("\\s*=\\s*"), limit = 2)
-                    val opNames = secondHalf.split(Regex("\\s*\\|\\s*"))
-
-                    // Find the definitions of the ops that are used for this opPointer
-                    val opDefinitions = opNames.map { (Regex("\\s+op\\s+$it\\(.*\\)").find(conceptBody)?.value ?: "")  }
-
-                    /* From this line on to the end of this block the code is written to replace all opNames with calls to their actual functions */
-                    val sb = StringBuilder(firstHalf)
-
-                    // Find out all needed parameters
-                    val functionParameters = opDefinitions.flatMap { opDefinition ->
-                        // find the parameters that are used for the op
-                        val opParameters = Regex("\\(.*\\)").find(opDefinition)?.value ?: ""
-                        // remove the `(` and `)` and then split the parameters
-                        removeFirstAndLastChar(opParameters).split(Regex("\\s*,\\s*"))
-                    }
-                        .filter { it.isNotEmpty() }
-                        .toSet()
-                        // add types to the parameters
-                        .map {
-                            if(it.endsWith("..."))
-                            // translate vararg parameters to the correct Kotlin syntax
-                                "vararg ${it.substring(0, it.length - 3)}: Any?"
-                            else "$it: Any?"
-                        }
-
-                    sb.append("(")
-                    sb.append(functionParameters.joinToString())
-                    sb.append("): Op = opGroup(")
-
-                    // Append calls to ops
-                    val functionCalls = opDefinitions.map { opDefinition ->
-                        // remove the `op` keyword and all `...`
-                        opDefinition.replace(Regex("(\\s+op\\s+)|(\\.\\.\\.)"), "")
-                    }
-
-                    sb.append(functionCalls.joinToString())
-
-                    sb.append(")\n")
-                    sb.toString()
+                    handleOpPointer(opPointerMatchResult, fileText)
                 }
 
             val scriptText = preliminaryScriptText
@@ -267,7 +216,7 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
                     )
                 }
                 // Replace all `enum` keywords with `enum class` and ensure that the name is capitalized
-                .replace(Regex("enum\\s+.")){
+                .replace(Regex("enum\\s+.")) {
                     makeLastCharUpperCase(
                         it.value.replace("enum", "enum class")
                     )
@@ -291,24 +240,110 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
                 }
                 .replace(Regex("\\s+var\\s+.+\\s")) { varMatchResult ->
                     val property = varMatchResult.value.replace("var", "val").dropLast(1)
-                    if(property.contains(':'))
+                    if (property.contains(':')) {
                         "$property\n"
-                    else
-                        "${property}: Any?\n"
+                    } else {
+                        "$property: Any?\n"
+                    }
                 }
 
             return StringScriptSource(scriptText, fileScriptSource.name)
         }
 
-        fun makeLastCharUpperCase(string: String): String {
+
+        /**
+         * This translates a match of a `op` keyword that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
+         * into a Kotlin function that returns a [GroupingOp].
+         *
+         * Example:
+         * ```
+         * op log = info | warn
+         * op info(msg)
+         * op warn(msg)
+         * ```
+         * is translated into
+         * ```
+         * fun log(msg: Any?): GroupingOp = opGroup(info(msg), warn(msg))
+         * ```
+         */
+        private fun handleOpPointer(opPointerMatchResult: MatchResult, fileText: String): String {
+            val preliminaryResult = opPointerMatchResult.value
+                // remove the whitespace character at the end of the matchResult
+                .dropLast(1)
+                // Replace all `op` keywords with `fun`
+                .replace("op", "fun")
+
+            // The index of the '{' character that starts the body of the concept that the "op" resides in
+            val conceptBodyStart = fileText.lastIndexOf('{', opPointerMatchResult.range.first)
+            // The index of the '}' character that ends the body of the concept that the "op" resides in
+            val conceptBodyEnd = fileText.indexOf('}', opPointerMatchResult.range.last)
+
+            // The body of the concept as string
+            val conceptBody = fileText.subSequence(conceptBodyStart, conceptBodyEnd)
+
+            // Split the definition of the operationPointer at the `=`
+            val (firstHalf, secondHalf) = preliminaryResult.split(Regex("\\s*=\\s*"), limit = 2)
+            // Split the grouped ops into separate strings
+            val opNames = secondHalf.split(Regex("\\s*\\|\\s*"))
+
+            val sb = StringBuilder(firstHalf)
+
+            sb.append("(")
+            // Find the definitions of the ops that are used for this opPointer
+            val opDefinitions = opNames.map { (Regex("\\s+op\\s+$it\\(.*\\)").find(conceptBody)?.value ?: "") }
+            // Append parameters needed for the function which are built by combining
+            // the parameters of the grouped ops
+            sb.append(buildFunctionParameters(opDefinitions))
+            sb.append("): Op = opGroup(")
+
+            // Append calls to ops
+            val functionCalls = opDefinitions.map { opDefinition ->
+                // remove the `op` keyword and all `...`
+                opDefinition.replace(Regex("(\\s+op\\s+)|(\\.\\.\\.)"), "")
+            }
+            sb.append(functionCalls.joinToString())
+
+            sb.append(")\n")
+            return sb.toString()
+        }
+
+        /**
+         * This combines all parameters of the ops in [opDefinitions] into a set of parameters
+         * that are needed to call all functions representing the ops and combines them into a string.
+         */
+        private fun buildFunctionParameters(opDefinitions: List<String>): String {
+            // Find out all needed parameters
+            val functionParameters = opDefinitions.flatMap { opDefinition ->
+                // find the parameters that are used for the op
+                val opParameters = Regex("\\(.*\\)").find(opDefinition)?.value ?: ""
+                // remove the `(` and `)` and then split the parameters
+                removeFirstAndLastChar(opParameters).split(Regex("\\s*,\\s*"))
+            }
+                .filter { it.isNotEmpty() }
+                .toSet()
+                // add types to the parameters
+                .map {
+                    if (it.endsWith("...")) {
+                        // translate vararg parameters to the correct Kotlin syntax
+                        "vararg ${it.substring(0, it.length - 3)}: Any?"
+                    } else {
+                        "$it: Any?"
+                    }
+                }
+
+            return functionParameters.joinToString()
+        }
+
+        private fun makeLastCharUpperCase(string: String): String {
             val lastCharAsUpper = string.last().uppercaseChar()
             return string.dropLast(1) + lastCharAsUpper
         }
 
-        fun removeFirstAndLastChar(string: String): String =
-            if(string.isEmpty())
+        private fun removeFirstAndLastChar(string: String): String =
+            if (string.isEmpty()) {
                 string
-            else
+            } else {
                 string.substring(1, string.length - 1)
+            }
     }
 }

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
@@ -19,16 +19,18 @@ import de.fraunhofer.aisec.codyze.core.executor.Executor
 import de.fraunhofer.aisec.codyze.core.timed
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.CokoBackend
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.Finding
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.GroupingOp
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.Import
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoConfiguration
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoSarifBuilder
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.CokoScript
 import io.github.detekt.sarif4k.Run
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.extension
 import kotlin.script.experimental.api.*
 import kotlin.script.experimental.api.SourceCode
+import kotlin.script.experimental.host.FileBasedScriptSource
 import kotlin.script.experimental.host.FileScriptSource
 import kotlin.script.experimental.host.StringScriptSource
 import kotlin.script.experimental.host.toScriptSource
@@ -81,6 +83,8 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
         /** Contains the class loaders of all evaluated scripts */
         private val classLoaders = mutableSetOf<ClassLoader>()
 
+        private val conceptTranslator = ConceptTranslator()
+
         /** Evaluates the given project script [sourceCode] against the given [backend]. */
         fun eval(
             sourceCode: String,
@@ -96,7 +100,16 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             baseClassLoader: ClassLoader? = null
         ): ResultWithDiagnostics<EvaluationResult> {
             val compilationConfiguration =
-                createJvmCompilationConfigurationFromTemplate<CokoScript>()
+                createJvmCompilationConfigurationFromTemplate<CokoScript>() {
+                    refineConfiguration {
+                        // the callback called if any of the listed file-level annotations are encountered in
+                        // the compiled script
+                        // the processing is defined by the `handler`, that may return refined configuration
+                        // depending on the annotations
+                        onAnnotations(Import::class, handler = ::configureImportDepsOnAnnotations)
+                    }
+
+                }
             val evaluationConfiguration =
                 createJvmEvaluationConfigurationFromTemplate<CokoScript> {
                     implicitReceivers(backend)
@@ -132,7 +145,7 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             val specEvaluator = SpecEvaluator()
             for (specFile in specFiles) {
                 val scriptSource = if (specFile.extension == "concepts") {
-                    transformConceptFile(specFile)
+                    conceptTranslator.transformConceptFile(specFile)
                 } else {
                     FileScriptSource(specFile.toFile())
                 }
@@ -195,155 +208,41 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
             return specEvaluator
         }
 
-        private fun transformConceptFile(specFile: Path): StringScriptSource {
-            val fileScriptSource = FileScriptSource(specFile.toFile())
+        // The handler that is called during script compilation in order to reconfigure compilation on the
+        // fly
+        fun configureImportDepsOnAnnotations(
+            context: ScriptConfigurationRefinementContext
+        ): ResultWithDiagnostics<ScriptCompilationConfiguration> {
+            val annotations =
+                // If no action is performed, the original configuration should be returned
+                context.collectedData?.get(ScriptCollectedData.foundAnnotations)?.takeIf { it.isNotEmpty() }
+                    ?: return context.compilationConfiguration.asSuccess()
 
-            val fileText = fileScriptSource.text
-            val preliminaryScriptText = fileText
-                // Remove all comments
-                // TODO: Is there a way to specify that all Regexes should not include matches found in comments?
-                .replace(Regex("//.*\\n"), "\n")
-                // Handle all `op` keywords that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
-                .replace(Regex("\\s+op\\s+.+=.+\\s")) { opPointerMatchResult ->
-                    handleOpPointer(opPointerMatchResult, fileText)
+            val scriptBaseDir = (context.script as? FileBasedScriptSource)?.file?.parentFile
+            val importedSources =
+                annotations.flatMap {
+//            (it as? Import)?.paths?.map { sourceName ->
+//                FileScriptSource(scriptBaseDir?.resolve(sourceName) ?: File(sourceName))
+//            }.orEmpty()
+
+                    (it as? Import)?.paths?.mapNotNull { sourceName ->
+                        val file = scriptBaseDir?.resolve(sourceName) ?: File(sourceName).normalize()
+                        val absoluteFile = file.absolutePath
+                        if(sourceName.endsWith(".codyze.kts"))
+                            FileScriptSource(file)
+                        else if (sourceName.endsWith(".concepts"))
+                            conceptTranslator.transformConceptFile(file.toPath())
+                        else null
+                    }.orEmpty()
                 }
 
-            val scriptText = preliminaryScriptText
-                // Replace all `concept` keywords with `interface` and ensure that the name is capitalized
-                .replace(Regex("concept\\s+.")) {
-                    makeLastCharUpperCase(
-                        it.value.replace("concept", "interface")
-                    )
-                }
-                // Replace all `enum` keywords with `enum class` and ensure that the name is capitalized
-                .replace(Regex("enum\\s+.")) {
-                    makeLastCharUpperCase(
-                        it.value.replace("enum", "enum class")
-                    )
-                }
-                // Ensure that all type names are capitalized
-                .replace(Regex(":\\s*[a-zA-Z]")) {
-                    it.value.uppercase()
-                }
-                // Replace all `op` keywords that represent an operation with `fun` and add types for the parameters
-                .replace(Regex("\\s+op\\s.+\\)\\s?")) { opMatchResult ->
-                    opMatchResult.value
-                        .replace("op", "fun")
-                        .replace(Regex(",( )?.*\\.\\.\\.")) {
-                            it.value.dropLast(3).replace(Regex(",( )?",), ", vararg ")
-                        }
-                        .replace(",", ": Any?,")
-                        .replace(Regex("[^(]\\)")) {
-                            "${it.value.dropLast(1)}: Any?): Op"
-                        }
-                        .plus("\n")
-                }
-                .replace(Regex("\\s+var\\s+.+\\s")) { varMatchResult ->
-                    val property = varMatchResult.value.replace("var", "val").dropLast(1)
-                    if (property.contains(':')) {
-                        "$property\n"
-                    } else {
-                        "$property: Any?\n"
-                    }
-                }
-
-            return StringScriptSource(scriptText, fileScriptSource.name)
-        }
-
-
-        /**
-         * This translates a match of a `op` keyword that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
-         * into a Kotlin function that returns a [GroupingOp].
-         *
-         * Example:
-         * ```
-         * op log = info | warn
-         * op info(msg)
-         * op warn(msg)
-         * ```
-         * is translated into
-         * ```
-         * fun log(msg: Any?): GroupingOp = opGroup(info(msg), warn(msg))
-         * ```
-         */
-        private fun handleOpPointer(opPointerMatchResult: MatchResult, fileText: String): String {
-            val preliminaryResult = opPointerMatchResult.value
-                // remove the whitespace character at the end of the matchResult
-                .dropLast(1)
-                // Replace all `op` keywords with `fun`
-                .replace("op", "fun")
-
-            // The index of the '{' character that starts the body of the concept that the "op" resides in
-            val conceptBodyStart = fileText.lastIndexOf('{', opPointerMatchResult.range.first)
-            // The index of the '}' character that ends the body of the concept that the "op" resides in
-            val conceptBodyEnd = fileText.indexOf('}', opPointerMatchResult.range.last)
-
-            // The body of the concept as string
-            val conceptBody = fileText.subSequence(conceptBodyStart, conceptBodyEnd)
-
-            // Split the definition of the operationPointer at the `=`
-            val (firstHalf, secondHalf) = preliminaryResult.split(Regex("\\s*=\\s*"), limit = 2)
-            // Split the grouped ops into separate strings
-            val opNames = secondHalf.split(Regex("\\s*\\|\\s*"))
-
-            val sb = StringBuilder(firstHalf)
-
-            sb.append("(")
-            // Find the definitions of the ops that are used for this opPointer
-            val opDefinitions = opNames.map { (Regex("\\s+op\\s+$it\\(.*\\)").find(conceptBody)?.value ?: "") }
-            // Append parameters needed for the function which are built by combining
-            // the parameters of the grouped ops
-            sb.append(buildFunctionParameters(opDefinitions))
-            sb.append("): Op = opGroup(")
-
-            // Append calls to ops
-            val functionCalls = opDefinitions.map { opDefinition ->
-                // remove the `op` keyword and all `...`
-                opDefinition.replace(Regex("(\\s+op\\s+)|(\\.\\.\\.)"), "")
+            return ScriptCompilationConfiguration(context.compilationConfiguration) {
+                if (importedSources.isNotEmpty()) importScripts.append(importedSources)
             }
-            sb.append(functionCalls.joinToString())
-
-            sb.append(")\n")
-            return sb.toString()
+                .asSuccess()
         }
 
-        /**
-         * This combines all parameters of the ops in [opDefinitions] into a set of parameters
-         * that are needed to call all functions representing the ops and combines them into a string.
-         */
-        private fun buildFunctionParameters(opDefinitions: List<String>): String {
-            // Find out all needed parameters
-            val functionParameters = opDefinitions.flatMap { opDefinition ->
-                // find the parameters that are used for the op
-                val opParameters = Regex("\\(.*\\)").find(opDefinition)?.value ?: ""
-                // remove the `(` and `)` and then split the parameters
-                removeFirstAndLastChar(opParameters).split(Regex("\\s*,\\s*"))
-            }
-                .filter { it.isNotEmpty() }
-                .toSet()
-                // add types to the parameters
-                .map {
-                    if (it.endsWith("...")) {
-                        // translate vararg parameters to the correct Kotlin syntax
-                        "vararg ${it.substring(0, it.length - 3)}: Any?"
-                    } else {
-                        "$it: Any?"
-                    }
-                }
-
-            return functionParameters.joinToString()
-        }
-
-        private fun makeLastCharUpperCase(string: String): String {
-            val lastCharAsUpper = string.last().uppercaseChar()
-            return string.dropLast(1) + lastCharAsUpper
-        }
-
-        private fun removeFirstAndLastChar(string: String): String =
-            if (string.isEmpty()) {
-                string
-            } else {
-                string.substring(1, string.length - 1)
-            }
     }
+
+
 }

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/CokoExecutor.kt
@@ -135,6 +135,7 @@ class CokoExecutor(private val configuration: CokoConfiguration, private val bac
          * @return A [SpecEvaluator] object containing the extracted information from all
          * [specFiles]
          */
+        @Suppress("complexity.CyclomaticComplexMethod")
         fun compileScriptsIntoSpecEvaluator(
             backend: CokoBackend,
             specFiles: List<Path>

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
@@ -1,0 +1,172 @@
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.GroupingOp
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.name
+import kotlin.script.experimental.host.FileScriptSource
+import kotlin.script.experimental.host.StringScriptSource
+
+class ConceptTranslator() {
+    private val conceptTranslations: MutableMap<Path, String> = mutableMapOf()
+
+    fun transformConceptFile(specFile: Path): StringScriptSource {
+        val absolutePath = specFile.normalize().absolute()
+        val cachedTranslation = conceptTranslations[absolutePath]
+        if(cachedTranslation != null)
+            return StringScriptSource(cachedTranslation, absolutePath.fileName.name)
+
+        val fileScriptSource = FileScriptSource(specFile.toFile())
+
+        val fileText = fileScriptSource.text
+        val preliminaryScriptText = fileText
+            // Remove all comments
+            // TODO: Is there a way to specify that all Regexes should not include matches found in comments?
+            .replace(Regex("//.*\\n"), "\n")
+            // Handle all `op` keywords that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
+            .replace(Regex("\\s+op\\s+.+=.+\\s")) { opPointerMatchResult ->
+                handleOpPointer(opPointerMatchResult, fileText)
+            }
+
+        val scriptText = preliminaryScriptText
+            // Replace all `concept` keywords with `interface` and ensure that the name is capitalized
+            .replace(Regex("concept\\s+.")) {
+                makeLastCharUpperCase(
+                    it.value.replace("concept", "interface")
+                )
+            }
+            // Replace all `enum` keywords with `enum class` and ensure that the name is capitalized
+            .replace(Regex("enum\\s+.")) {
+                makeLastCharUpperCase(
+                    it.value.replace("enum", "enum class")
+                )
+            }
+            // Ensure that all type names are capitalized
+            .replace(Regex(":\\s*[a-zA-Z]")) {
+                it.value.uppercase()
+            }
+            // Replace all `op` keywords that represent an operation with `fun` and add types for the parameters
+            .replace(Regex("\\s+op\\s.+\\)\\s?")) { opMatchResult ->
+                opMatchResult.value
+                    .replace("op", "fun")
+                    .replace(Regex(",( )?.*\\.\\.\\.")) {
+                        it.value.dropLast(3).replace(Regex(",( )?",), ", vararg ")
+                    }
+                    .replace(",", ": Any?,")
+                    .replace(Regex("[^(]\\)")) {
+                        "${it.value.dropLast(1)}: Any?): Op"
+                    }
+                    .plus("\n")
+            }
+            // Replace all `var` keywords with `val` and add a type if none is given
+            .replace(Regex("\\s+var\\s+.+\\s")) { varMatchResult ->
+                val property = varMatchResult.value.replace("var", "val").dropLast(1)
+                if (property.contains(':')) {
+                    "$property\n"
+                } else {
+                    "$property: Any\n"
+                }
+            }
+
+        conceptTranslations[absolutePath] = scriptText
+        return StringScriptSource(scriptText, fileScriptSource.name)
+    }
+
+
+    /**
+     * This translates a match of a `op` keyword that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
+     * into a Kotlin function that returns a [GroupingOp].
+     *
+     * Example:
+     * ```
+     * op log = info | warn
+     * op info(msg)
+     * op warn(msg)
+     * ```
+     * is translated into
+     * ```
+     * fun log(msg: Any?): GroupingOp = opGroup(info(msg), warn(msg))
+     * ```
+     */
+    private fun handleOpPointer(opPointerMatchResult: MatchResult, fileText: String): String {
+        val preliminaryResult = opPointerMatchResult.value
+            // remove the whitespace character at the end of the matchResult
+            .dropLast(1)
+            // Replace all `op` keywords with `fun`
+            .replace("op", "fun")
+
+        // The index of the '{' character that starts the body of the concept that the "op" resides in
+        val conceptBodyStart = fileText.lastIndexOf('{', opPointerMatchResult.range.first)
+        // The index of the '}' character that ends the body of the concept that the "op" resides in
+        val conceptBodyEnd = fileText.indexOf('}', opPointerMatchResult.range.last)
+
+        // The body of the concept as string
+        val conceptBody = fileText.subSequence(conceptBodyStart, conceptBodyEnd)
+
+        // Split the definition of the operationPointer at the `=`
+        val (firstHalf, secondHalf) = preliminaryResult.split(Regex("\\s*=\\s*"), limit = 2)
+        // Split the grouped ops into separate strings
+        val opNames = secondHalf.split(Regex("\\s*\\|\\s*"))
+
+        val sb = StringBuilder(firstHalf)
+
+        sb.append("(")
+        // Find the definitions of the ops that are used for this opPointer
+        val opDefinitions = opNames.map { (Regex("\\s+op\\s+$it\\(.*\\)").find(conceptBody)?.value ?: "") }
+        // Append parameters needed for the function which are built by combining
+        // the parameters of the grouped ops
+        sb.append(buildFunctionParameters(opDefinitions))
+        sb.append("): Op = opGroup(")
+
+        // Append calls to ops
+        val functionCalls = opDefinitions.map { opDefinition ->
+            // remove the `op` keyword and all `...`
+            opDefinition.replace(Regex("(\\s+op\\s+)|(\\.\\.\\.)"), "")
+        }
+        sb.append(functionCalls.joinToString())
+
+        sb.append(")\n")
+        return sb.toString()
+    }
+
+    /**
+     * This combines all parameters of the ops in [opDefinitions] into a set of parameters
+     * that are needed to call all functions representing the ops and combines them into a string.
+     */
+    private fun buildFunctionParameters(opDefinitions: List<String>): String {
+        // Find out all needed parameters
+        val functionParameters = opDefinitions.flatMap { opDefinition ->
+            // find the parameters that are used for the op
+            val opParameters = Regex("\\(.*\\)").find(opDefinition)?.value ?: ""
+            // remove the `(` and `)` and then split the parameters
+            removeFirstAndLastChar(opParameters).split(Regex("\\s*,\\s*"))
+        }
+            .filter { it.isNotEmpty() }
+            .toSet()
+            // add types to the parameters
+            .map {
+                if (it.endsWith("...")) {
+                    // translate vararg parameters to the correct Kotlin syntax
+                    "vararg ${it.substring(0, it.length - 3)}: Any?"
+                } else {
+                    "$it: Any?"
+                }
+            }
+
+        return functionParameters.joinToString()
+    }
+
+    private fun makeLastCharUpperCase(string: String): String {
+        val lastCharAsUpper = string.last().uppercaseChar()
+        return string.dropLast(1) + lastCharAsUpper
+    }
+
+    private fun removeFirstAndLastChar(string: String): String =
+        if (string.isEmpty()) {
+            string
+        } else {
+            string.substring(1, string.length - 1)
+        }
+
+}
+

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.GroupingOp
@@ -7,14 +23,16 @@ import kotlin.io.path.name
 import kotlin.script.experimental.host.FileScriptSource
 import kotlin.script.experimental.host.StringScriptSource
 
-class ConceptTranslator() {
+class ConceptTranslator {
     private val conceptTranslations: MutableMap<Path, String> = mutableMapOf()
 
+    @Suppress("MagicNumber")
     fun transformConceptFile(specFile: Path): StringScriptSource {
         val absolutePath = specFile.normalize().absolute()
         val cachedTranslation = conceptTranslations[absolutePath]
-        if(cachedTranslation != null)
+        if (cachedTranslation != null) {
             return StringScriptSource(cachedTranslation, absolutePath.fileName.name)
+        }
 
         val fileScriptSource = FileScriptSource(specFile.toFile())
 
@@ -72,9 +90,9 @@ class ConceptTranslator() {
         return StringScriptSource(scriptText, fileScriptSource.name)
     }
 
-
     /**
-     * This translates a match of a `op` keyword that represent an operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
+     * This translates a match of a `op` keyword that represent an
+     * operationPointer (`'op' <name> '=' <name> ('|' <name>)*`)
      * into a Kotlin function that returns a [GroupingOp].
      *
      * Example:
@@ -133,6 +151,7 @@ class ConceptTranslator() {
      * This combines all parameters of the ops in [opDefinitions] into a set of parameters
      * that are needed to call all functions representing the ops and combines them into a string.
      */
+    @Suppress("MagicNumber")
     private fun buildFunctionParameters(opDefinitions: List<String>): String {
         // Find out all needed parameters
         val functionParameters = opDefinitions.flatMap { opDefinition ->
@@ -167,6 +186,4 @@ class ConceptTranslator() {
         } else {
             string.substring(1, string.length - 1)
         }
-
 }
-

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
@@ -129,7 +129,7 @@ class ConceptTranslator {
 
         sb.append("(")
         // Find the definitions of the ops that are used for this opPointer
-        val opDefinitions = opNames.map { (Regex("\\s+op\\s+$it\\(.*\\)").find(conceptBody)?.value ?: "") }
+        val opDefinitions = opNames.map { (Regex("\\s+op\\s+$it\\(.*\\)").find(conceptBody)?.value.orEmpty()) }
         // Append parameters needed for the function which are built by combining
         // the parameters of the grouped ops
         sb.append(buildFunctionParameters(opDefinitions))
@@ -155,7 +155,7 @@ class ConceptTranslator {
         // Find out all needed parameters
         val functionParameters = opDefinitions.flatMap { opDefinition ->
             // find the parameters that are used for the op
-            val opParameters = Regex("\\(.*\\)").find(opDefinition)?.value ?: ""
+            val opParameters = Regex("\\(.*\\)").find(opDefinition)?.value.orEmpty()
             // remove the `(` and `)` and then split the parameters
             removeFirstAndLastChar(opParameters).split(Regex("\\s*,\\s*"))
         }

--- a/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/host/ConceptTranslator.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.dsl.GroupingOp

--- a/codyze-specification-languages/coko/coko-dsl/src/main/resources/concept.g4
+++ b/codyze-specification-languages/coko/coko-dsl/src/main/resources/concept.g4
@@ -1,0 +1,69 @@
+grammar concept;
+file: (concept | ruleSet | rule | enum)* EOF;
+
+name: ID | EMPTY_ID;
+type: ID;
+
+concept: 'concept' name conceptBody;
+conceptBody: '{' conceptItem* '}';
+conceptItem: variable | operation | operationPointer;
+variable: 'var' name (':' type)?;
+operationPointer: 'op' name '=' name ('|' name)*;
+operation: 'op' name parameterClause;
+parameterClause: '(' parameterList? ')';
+parameterList: parameter (',' parameter)*;
+parameter: name | name '...';
+
+enum: 'enum' name enumBody;
+enumBody: '{' name (',' name)* '}';
+
+ruleSet: 'ruleset' name ruleSetBody;
+ruleSetBody: '{' rule+ '}';
+
+rule: 'rule' name ruleBody;
+ruleBody: '{' ruleItem* '}';
+ruleItem: ruleVariable | when;
+
+ruleVariable: 'var' name ':' type;
+when: 'when' condition '{' whenBody '}';
+whenBody: assert*;
+
+assert: assertCall | assertEnsure;
+
+assertCall: 'call' opReference assertCallLocation?;
+assertCallLocation: eogDirection 'in' eogScope;
+assertEnsure: 'ensure' booleanExpression;
+
+eogScope: 'function scope'; // currently, we only support function scope
+eogDirection: 'afterwards' | 'before' | 'somewhere';
+
+condition: booleanExpression;
+expression:
+  name '.' name parameterClause #callExpression |
+  expression '.' name #memberExpression |
+  name #referenceExpression |
+  literal #literalExpression;
+booleanExpression:
+  lhs op rhs #comparison |
+  lhs IN array #rangeExpression |
+  opReference #opExpression |
+  booleanExpression AND booleanExpression #andExpression;
+array: '[' arrayElement (',' arrayElement)* ']';
+arrayElement: literal | name;
+lhs: expression;
+op: OPERATOR;
+rhs: expression;
+literal: LITERAL;
+
+opReference: name '::' (name | WILDCARD) parameterClause;
+
+AND: 'and';
+OR: 'or';
+IN: 'in';
+WILDCARD: '*';
+LITERAL: [0-9]+;
+EMPTY_ID: '_'; // empty identifier
+ID : [a-zA-Z]+;             // identifier
+WS : [ \t\r\n]+ -> skip; // skip spaces, tabs, newlines
+OPERATOR: '==' | '<=' | '>=' | '!=';
+LINE_COMMENT: '//' ~[\r\n]* -> skip; // skip comments

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTest.kt
@@ -1,0 +1,147 @@
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
+
+import de.fraunhofer.aisec.codyze.backends.cpg.CPGConfiguration
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host.CokoExecutor
+import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
+import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ConceptTranslationTest {
+
+    private val sourceFiles = listOfNotNull(
+        CokoCpgIntegrationTest::class.java.classLoader
+            .getResource("IntegrationTests/CokoCpg/Main.java"),
+        CokoCpgIntegrationTest::class.java.classLoader
+            .getResource("IntegrationTests/CokoCpg/SimpleOrder.java")
+    ).map { Path(it.path) }.also { assertEquals(2, it.size) }
+
+    val cpgConfiguration =
+        CPGConfiguration(
+            source = sourceFiles,
+            useUnityBuild = false,
+            typeSystemActiveInFrontend = true,
+            debugParser = false,
+            disableCleanup = false,
+            codeInNodes = true,
+            matchCommentsToNodes = false,
+            processAnnotations = false,
+            failOnError = false,
+            useParallelFrontends = false,
+            defaultPasses = true,
+            additionalLanguages = setOf(),
+            symbols = mapOf(),
+            includeBlocklist = listOf(),
+            includePaths = listOf(),
+            includeAllowlist = listOf(),
+            loadIncludes = false,
+            passes = listOf(UnreachableEOGPass::class, EdgeCachePass::class),
+        )
+
+    @Test
+    fun `test simple concept translation`() {
+        val specFiles = listOfNotNull(
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/bsi-tr.concepts"),
+        ).map { Path(it.path) }
+
+        val cokoConfiguration =
+            CokoConfiguration(
+                goodFindings = true,
+                pedantic = false,
+                spec = specFiles,
+                disabledSpecRules = emptyList(),
+            )
+
+        val backend = CokoCpgBackend(cpgConfiguration)
+        val specEvaluator = CokoExecutor.compileScriptsIntoSpecEvaluator(backend, specFiles)
+
+        val expectedInterfaceToExpectedMembers = mapOf(
+            "Cypher" to listOf("algo", "mode", "keySize", "tagSize"),
+            "InitializationVector" to listOf("size"),
+            "Encryption" to listOf("cypher", "iv", "encrypt", "decrypt")
+        )
+
+        assertEquals(expectedInterfaceToExpectedMembers.size, specEvaluator.types.size)
+
+        for((expectedInterface, members) in expectedInterfaceToExpectedMembers) {
+            val actualInterfaces =  specEvaluator.types.filter {it.simpleName?.contains(expectedInterface) ?: false}
+            assertEquals(1, actualInterfaces.size, "Found none or more than one actual interface representing the concept \"$expectedInterface\"")
+            val actualInterface = actualInterfaces.first()
+
+            assertTrue(actualInterface.members.map { it.name }.containsAll(members))
+        }
+    }
+
+    @Test
+    fun `test concept translation with op pointer`() {
+        val specFiles = listOfNotNull(
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/some.concepts"),
+        ).map { Path(it.path) }
+
+        val cokoConfiguration =
+            CokoConfiguration(
+                goodFindings = true,
+                pedantic = false,
+                spec = specFiles,
+                disabledSpecRules = emptyList(),
+            )
+
+        val backend = CokoCpgBackend(cpgConfiguration)
+        val specEvaluator = CokoExecutor.compileScriptsIntoSpecEvaluator(backend, specFiles)
+
+        val expectedInterfaceToExpectedMembers = mapOf(
+            "Logging" to listOf("log", "info", "warn", "error"),
+            "Database" to listOf("init", "insert"),
+            "UserContext" to listOf("user")
+        )
+
+        assertEquals(3, specEvaluator.types.size)
+        for((expectedInterface, members) in expectedInterfaceToExpectedMembers) {
+            val actualInterfaces =  specEvaluator.types.filter {it.simpleName?.contains(expectedInterface) ?: false}
+            assertEquals(1, actualInterfaces.size, "Found none or more than one actual interface representing the concept \"$expectedInterface\"")
+            val actualInterface = actualInterfaces.first()
+            assertTrue(actualInterface.members.map { it.name }.containsAll(members))
+
+            if(expectedInterface == "Logging") {
+                val log = actualInterface.members.firstOrNull { it.name == "log" }
+                assertNotNull(log)
+                assertFalse(log.isAbstract)
+            }
+        }
+    }
+
+    @Test
+    fun `test concept in combination with coko scripts`() {
+        val specFiles = listOfNotNull(
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/followedBy.concepts"),
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/followedByImplementations.codyze.kts"),
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/followedByRule.codyze.kts"),
+        ).map { Path(it.path) }
+
+        val cokoConfiguration =
+            CokoConfiguration(
+                goodFindings = true,
+                pedantic = false,
+                spec = specFiles,
+                disabledSpecRules = emptyList(),
+            )
+
+        val backend = CokoCpgBackend(cpgConfiguration)
+        val executor = CokoExecutor(cokoConfiguration, backend)
+
+        val run = executor.evaluate()
+        assertEquals(1, run.results?.size)
+    }
+}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
 
 import de.fraunhofer.aisec.codyze.backends.cpg.CPGConfiguration
@@ -41,7 +40,6 @@ class ConceptTranslationTest {
         CPGConfiguration(
             source = sourceFiles,
             useUnityBuild = false,
-            typeSystemActiveInFrontend = true,
             debugParser = false,
             disableCleanup = false,
             codeInNodes = true,

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
 
 import de.fraunhofer.aisec.codyze.backends.cpg.CPGConfiguration

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
@@ -8,8 +8,6 @@ import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
-import kotlin.reflect.full.isSubtypeOf
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -71,9 +69,13 @@ class ConceptTranslationTest {
 
         assertEquals(expectedInterfaceToExpectedMembers.size, specEvaluator.types.size)
 
-        for((expectedInterface, members) in expectedInterfaceToExpectedMembers) {
-            val actualInterfaces =  specEvaluator.types.filter {it.simpleName?.contains(expectedInterface) ?: false}
-            assertEquals(1, actualInterfaces.size, "Found none or more than one actual interface representing the concept \"$expectedInterface\"")
+        for ((expectedInterface, members) in expectedInterfaceToExpectedMembers) {
+            val actualInterfaces = specEvaluator.types.filter { it.simpleName?.contains(expectedInterface) ?: false }
+            assertEquals(
+                1,
+                actualInterfaces.size,
+                "Found none or more than one actual interface representing the concept \"$expectedInterface\""
+            )
             val actualInterface = actualInterfaces.first()
 
             assertTrue(actualInterface.members.map { it.name }.containsAll(members))
@@ -105,13 +107,17 @@ class ConceptTranslationTest {
         )
 
         assertEquals(3, specEvaluator.types.size)
-        for((expectedInterface, members) in expectedInterfaceToExpectedMembers) {
-            val actualInterfaces =  specEvaluator.types.filter {it.simpleName?.contains(expectedInterface) ?: false}
-            assertEquals(1, actualInterfaces.size, "Found none or more than one actual interface representing the concept \"$expectedInterface\"")
+        for ((expectedInterface, members) in expectedInterfaceToExpectedMembers) {
+            val actualInterfaces = specEvaluator.types.filter { it.simpleName?.contains(expectedInterface) ?: false }
+            assertEquals(
+                1,
+                actualInterfaces.size,
+                "Found none or more than one actual interface representing the concept \"$expectedInterface\""
+            )
             val actualInterface = actualInterfaces.first()
             assertTrue(actualInterface.members.map { it.name }.containsAll(members))
 
-            if(expectedInterface == "Logging") {
+            if (expectedInterface == "Logging") {
                 val log = actualInterface.members.firstOrNull { it.name == "log" }
                 assertNotNull(log)
                 assertFalse(log.isAbstract)

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/WheneverEvaluatorTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/WheneverEvaluatorTest.kt
@@ -37,7 +37,6 @@ class WheneverEvaluatorTest {
         CPGConfiguration(
             source = sourceFiles,
             useUnityBuild = false,
-            typeSystemActiveInFrontend = true,
             debugParser = false,
             disableCleanup = false,
             codeInNodes = true,

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/WheneverEvaluatorTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/WheneverEvaluatorTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
+
+import de.fraunhofer.aisec.codyze.backends.cpg.CPGConfiguration
+import de.fraunhofer.aisec.codyze.backends.cpg.coko.CokoCpgBackend
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host.CokoExecutor
+import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
+import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
+import io.github.detekt.sarif4k.ResultKind
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+import kotlin.test.assertEquals
+
+// TODO: should probably in codyze-backends or coko-core
+class WheneverEvaluatorTest {
+
+    private val sourceFiles = listOfNotNull(
+        CokoCpgIntegrationTest::class.java.classLoader
+            .getResource("concept/CipherTestFile.java"),
+    ).map { Path(it.path) }.also { assertEquals(1, it.size) }
+
+    val cpgConfiguration =
+        CPGConfiguration(
+            source = sourceFiles,
+            useUnityBuild = false,
+            typeSystemActiveInFrontend = true,
+            debugParser = false,
+            disableCleanup = false,
+            codeInNodes = true,
+            matchCommentsToNodes = false,
+            processAnnotations = false,
+            failOnError = false,
+            useParallelFrontends = false,
+            defaultPasses = true,
+            additionalLanguages = setOf(),
+            symbols = mapOf(),
+            includeBlocklist = listOf(),
+            includePaths = listOf(),
+            includeAllowlist = listOf(),
+            loadIncludes = false,
+            passes = listOf(UnreachableEOGPass::class, EdgeCachePass::class),
+        )
+
+    /**
+     * Performs an end-to-end integration test of Codyze with the [CokoExecutor] and the [CokoCpgBackend] backend.
+     */
+    @Test
+    fun `test coko with cpg backend and multiple spec files`() {
+        val specFiles = listOfNotNull(
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/bsi-tr-rules.codyze.kts"),
+            CokoCpgIntegrationTest::class.java.classLoader
+                .getResource("concept/jca-cipher.codyze.kts")
+        ).map { Path(it.path) }.also { assertEquals(2, it.size) }
+
+        val cokoConfiguration =
+            CokoConfiguration(
+                goodFindings = true,
+                pedantic = false,
+                spec = specFiles,
+                disabledSpecRules = emptyList(),
+            )
+
+        val backend = CokoCpgBackend(cpgConfiguration)
+        val executor = CokoExecutor(cokoConfiguration, backend)
+
+        val run = executor.evaluate()
+
+        // assertions for the order rule
+        assertEquals(1, run.results?.size, "Expected to find one result but was ${run.results?.size}")
+        assertEquals(ResultKind.Fail, run.results?.firstOrNull()?.kind, "Result was not fail")
+    }
+}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/CipherTestFile.java
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/CipherTestFile.java
@@ -1,0 +1,39 @@
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+public class CipherTestFile {
+
+    public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchProviderException, NoSuchPaddingException, InvalidKeySpecException, InvalidKeyException, InvalidAlgorithmParameterException {
+        Security.addProvider(new BouncyCastleProvider());
+
+        String transform = "AES/CBC/NoPadding";
+        Cipher c = Cipher.getInstance(transform, "BC");
+
+        SecureRandom sr = new SecureRandom();
+        byte[] iv = sr.generateSeed(16);
+        IvParameterSpec ivParamSpec = new IvParameterSpec(iv);
+
+        byte[] rawKey = sr.generateSeed(32);
+        SecretKeyFactory skf = SecretKeyFactory.getInstance("AES");
+        Key k = skf.generateSecret(new SecretKeySpec(rawKey, "AES"));
+
+        c.init(Cipher.ENCRYPT_MODE, k, ivParamSpec);
+        c.doFinal();
+        System.out.println(c);
+    }
+
+}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
@@ -1,5 +1,7 @@
 @file:Import("bsi-tr.concepts")
 
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.HasTransformation
+
 enum class Algorithm {
     AES, DES, TripleDES
 }
@@ -15,29 +17,40 @@ enum class Mode{
     CTR
 }
 
+interface Cypher {
+    val algo: HasTransformation<Algorithm>
+    val mode: HasTransformation<Mode>
+    val keySize: HasTransformation<Int> // in bits
+    val tagSize: HasTransformation<Int> // in bits; only applicable for mode == CCM
+}
+
+interface InitializationVector {
+    val size: Int // in bits
+}
+
 interface Encryption {
     val cypher: Cypher
-    val iv: Op
+    val iv: InitializationVector
 
     fun encrypt(plaintext: Any?): Op
     fun decrypt(ciphertext: Any?): Op
 }
 
-interface Cypher {
-    var algo: Algorithm
-    var mode: Mode
-    var keySize: Int // in bits
-    var tagSize: Int // in bits; only applicable for mode == CCM
-}
 
 @RuleSet
 class GoodCrypto {
     @Rule
     fun `must be AES`(enc: Encryption) =
         whenever(enc.encrypt(Wildcard)) {
-            ensure { enc.cypher.algo == Algorithm.AES}
-            ensure { enc.cypher.mode in list[Mode.CCM, Mode.GCM, Mode.CTR] }
+            ensure { enc.cypher.algo eq Algorithm.AES }
+            ensure { enc.cypher.mode within list[Mode.CCM, Mode.GCM, Mode.CTR] }
+            ensure { enc.cypher.keySize within list[128, 192, 256]}
         }
 
+    @Rule
+    fun `modes of operation`(enc: Encryption) =
+        whenever({ enc.encrypt(Wildcard) and (enc.cypher.mode eq Mode.CCM) }) {
+            ensure { enc.cypher.tagSize geq 96 }
+        }
 }
 

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
@@ -1,0 +1,43 @@
+@file:Import("bsi-tr.concepts")
+
+enum class Algorithm {
+    AES, DES, TripleDES
+}
+
+enum class Mode{
+    // Cipher Block Chaining Message Authentication
+    CCM,
+    // Galois/Counter Mode
+    GCM,
+    // Cipher Block Chaining
+    CBC,
+    // Counter Mode
+    CTR
+}
+
+interface Encryption {
+    val cypher: Cypher
+    val iv: Op
+
+    fun encrypt(plaintext: Any?): Op
+    fun decrypt(ciphertext: Any?): Op
+}
+
+interface Cypher {
+    var algo: Algorithm
+    var mode: Mode
+    var keySize: Int // in bits
+    var tagSize: Int // in bits; only applicable for mode == CCM
+}
+
+@RuleSet
+class GoodCrypto {
+    @Rule
+    fun `must be AES`(enc: Encryption) =
+        whenever(enc.encrypt(Wildcard)) {
+            ensure { enc.cypher.algo == Algorithm.AES}
+            ensure { enc.cypher.mode in list[Mode.CCM, Mode.GCM, Mode.CTR] }
+        }
+
+}
+

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
@@ -1,12 +1,13 @@
-@file:Import("bsi-tr.concepts")
+//@file:Import("bsi-tr.concepts")
 
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.HasTransformation
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.DataItem
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.value
 
 enum class Algorithm {
     AES, DES, TripleDES
 }
 
-enum class Mode{
+enum class Mode {
     // Cipher Block Chaining Message Authentication
     CCM,
     // Galois/Counter Mode
@@ -18,10 +19,10 @@ enum class Mode{
 }
 
 interface Cypher {
-    val algo: HasTransformation<Algorithm>
-    val mode: HasTransformation<Mode>
-    val keySize: HasTransformation<Int> // in bits
-    val tagSize: HasTransformation<Int> // in bits; only applicable for mode == CCM
+    val algo: DataItem<Algorithm>
+    val mode: DataItem<Mode>
+    val keySize: DataItem<Int> // in bits
+    val tagSize: DataItem<Int> // in bits; only applicable for mode == CCM
 }
 
 interface InitializationVector {
@@ -37,11 +38,11 @@ interface Encryption {
 }
 
 
-@RuleSet
-class GoodCrypto {
+//@RuleSet
+//class GoodCrypto {
     @Rule
     fun `must be AES`(enc: Encryption) =
-        whenever(enc.encrypt(Wildcard)) {
+        whenever({ call(enc.encrypt(Wildcard)) }) {
             ensure { enc.cypher.algo eq Algorithm.AES }
             ensure { enc.cypher.mode within list[Mode.CCM, Mode.GCM, Mode.CTR] }
             ensure { enc.cypher.keySize within list[128, 192, 256]}
@@ -49,8 +50,8 @@ class GoodCrypto {
 
     @Rule
     fun `modes of operation`(enc: Encryption) =
-        whenever({ enc.encrypt(Wildcard) and (enc.cypher.mode eq Mode.CCM) }) {
+        whenever({ call(enc.encrypt(Wildcard)) and (enc.cypher.mode eq Mode.CCM) }) {
             ensure { enc.cypher.tagSize geq 96 }
         }
-}
+//}
 

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr-rules.codyze.kts
@@ -1,7 +1,6 @@
 //@file:Import("bsi-tr.concepts")
 
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.DataItem
-import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.value
 
 enum class Algorithm {
     AES, DES, TripleDES
@@ -45,13 +44,13 @@ interface Encryption {
         whenever({ call(enc.encrypt(Wildcard)) }) {
             ensure { enc.cypher.algo eq Algorithm.AES }
             ensure { enc.cypher.mode within list[Mode.CCM, Mode.GCM, Mode.CTR] }
-            ensure { enc.cypher.keySize within list[128, 192, 256]}
+//            ensure { enc.cypher.keySize within list[128, 192, 256]}
         }
 
-    @Rule
-    fun `modes of operation`(enc: Encryption) =
-        whenever({ call(enc.encrypt(Wildcard)) and (enc.cypher.mode eq Mode.CCM) }) {
-            ensure { enc.cypher.tagSize geq 96 }
-        }
+//    @Rule
+//    fun `modes of operation`(enc: Encryption) =
+//        whenever({ call(enc.encrypt(Wildcard)) and (enc.cypher.mode eq Mode.CCM) }) {
+//            ensure { enc.cypher.tagSize geq 96 }
+//        }
 //}
 

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr.concepts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/bsi-tr.concepts
@@ -1,0 +1,66 @@
+// This concepts file provides a ruleset about "Good Crypto", which we should be able to
+// reference in some other concept file
+
+enum Algorithm {
+  AES, DES, TripleDES
+}
+
+enum Mode {
+  // Cipher Block Chaining Message Authentication
+  CCM,
+  // Galois/Counter Mode
+  GCM,
+  // Cipher Block Chaining
+  CBC,
+  // Counter Mode
+  CTR
+}
+
+concept Cypher {
+  var algo: Algorithm
+  var mode: Mode
+  var keySize: int // in bits
+  var tagSize: int // in bits; only applicable for mode == CCM
+}
+
+concept InitializationVector {
+  var size: int // in bits
+}
+
+concept Encryption {
+  var cypher: Cypher
+  var iv: InitializationVector
+
+  op encrypt(plaintext)
+  op decrypt(ciphertext)
+}
+
+//ruleset GoodCrypto {
+//  // Relates to 2.1.1 Betriebsarten
+//  rule MustBeAES {
+//    var enc: Encryption
+//
+//    when enc::encrypt(_) {
+//      ensure enc.cypher.algo == AES
+//      ensure enc.cypher.mode in [CCM, GCM, CTR]
+//      ensure enc.cypher.keySize in [128, 192, 256]
+//    }
+//  }
+//
+//  // Relates to 2.1.2 Betriebsbedingungen - CCM
+//  rule ModesOfOperation {
+//    var enc: Encryption
+//
+//    when enc::encrypt(_) and enc.cypher.mode == CCM {
+//      ensure enc.cypher.tagSize >= 96
+//    }
+//
+//    when enc::encrypt(_) and enc.cypher.mode == GCM {
+//      ensure enc.iv.size >= 96
+//    }
+//
+//    when enc::encrypt(_) and enc.cypher.mode in [CCM, GCM, CTR] {
+//      // TODO: iv should not repeat itself
+//    }
+//  }
+//}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/followedBy.concepts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/followedBy.concepts
@@ -1,0 +1,11 @@
+concept LoggingForTest {
+  op log(msg, args...)
+}
+
+concept ObjectRelationalMapperForTest {
+  op insert(obj)
+}
+
+concept UserContextForTest {
+  var user
+}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/followedByImplementations.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/followedByImplementations.codyze.kts
@@ -1,0 +1,33 @@
+@file:Import("followedBy.concepts")
+
+plugins { id("cpg") }
+
+class JavaLoggingTest : LoggingForTest {
+    override fun log(message: Any?, vararg args: Any?) = op {
+        definition("java.util.logging.Logger.info") {
+            signature {
+                group {
+                    - message
+                    args.forEach { - it }
+                }
+            }
+        }
+    }
+}
+
+class JDBCTest : ObjectRelationalMapperForTest {
+    override fun insert(obj: Any?) = op {
+        definition("java.sql.Statement.executeUpdate") {
+            signature {
+                group {
+                    - "INSERT.*"
+                    - obj
+                }
+            }
+        }
+    }
+}
+
+class JavalinJWTTest : UserContextForTest {
+    override val user = cpgCallFqn("javalinjwt.JavalinJWT.getTokenFromHeader")
+}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/followedByRule.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/followedByRule.codyze.kts
@@ -1,0 +1,6 @@
+@file:Import("followedBy.concepts")
+
+// TODO: can we "assert" that the ctx.user is not null here?
+@Rule("This is a dummy description.")
+fun DBActionsAreAlwaysLogged(db: ObjectRelationalMapperForTest, log: LoggingForTest, ctx: UserContextForTest) =
+    db.insert(Wildcard) followedBy log.log(".*", ctx.user)

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/jca-cipher.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/jca-cipher.codyze.kts
@@ -1,0 +1,88 @@
+@file:Import("bsi-tr-rules.codyze.kts")
+
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.DataItem
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.value
+
+class JCACipher {
+    fun getInstance(transformation: Any, provider: Any? = null) = op {
+        "javax.crypto.Cipher.getInstance" {
+            signature(transformation)
+            signature(transformation, provider)
+        }
+    }
+
+    fun init(opmode: Any, certificate: Any?, random: Any?, key: Any?, params: Any?) = op {
+        "javax.crypto.Cipher.init" {
+            signature(opmode, certificate)
+            signature(opmode, certificate, random)
+            signature(opmode, key)
+            signature(opmode, key, params)
+            signature(opmode, key, params, random)
+            signature(opmode, key, random)
+
+        }
+    }
+
+    fun doFinal(input: Any?, output: Any?, outputOffset: Any?, inputOffset: Any?, inputLen: Any?) = op {
+        "javax.crypto.Cipher.doFinal" {
+            signature()
+            signature(input)
+            signature(output, outputOffset)
+            signature(input, inputOffset, inputLen)
+            signature(input, inputOffset, inputLen, output)
+            signature(input, inputOffset, inputLen, output, outputOffset)
+            signature(input, output)
+        }
+    }
+}
+
+class JCAEncryptionImpl: Bsi_tr_rules_codyze.Encryption {
+    private val jcaCipher = JCACipher()
+    override val cypher: Bsi_tr_rules_codyze.Cypher
+        get() = JCACipherImpl()
+    override val iv: Bsi_tr_rules_codyze.InitializationVector
+        get() = TODO("Not yet implemented")
+
+    override fun encrypt(plaintext: Any?): Op =
+        jcaCipher.doFinal(plaintext, Wildcard, Wildcard, Wildcard, Wildcard) with
+                jcaCipher.init(".*ENCRYPT_MODE", Wildcard, Wildcard, Wildcard, Wildcard)
+
+    override fun decrypt(ciphertext: Any?): Op {
+        TODO("Not yet implemented")
+    }
+
+}
+
+// "AES/CBC/Padding"
+class JCACipherImpl: Bsi_tr_rules_codyze.Cypher {
+    val cipher = JCACipher()
+
+    override val algo: DataItem<Bsi_tr_rules_codyze.Algorithm>
+        get() = cipher.getInstance(Wildcard, Wildcard).arguments[1] withTransformation { dataItem ->
+            val stringValue = dataItem.value as? String
+            if(dataItem.value == null)
+                TransformationResult.failure("Value of BackendDataItem is null.")
+            else if(stringValue == null) {
+                TransformationResult.failure("Value of BackendDataItem is not a string.")
+            }
+            else {
+                val (algo, _) = stringValue.partition { it == '/' }
+                val algoEnum = Bsi_tr_rules_codyze.Algorithm.values().firstOrNull {  it.name == algo.uppercase() }
+                if(algoEnum == null)
+                    TransformationResult.failure("Could not resolve the string value to an algorithm")
+                else
+                    TransformationResult.success(algoEnum)
+            }
+        }
+    override val mode: DataItem<Bsi_tr_rules_codyze.Mode>
+        get() = value(Bsi_tr_rules_codyze.Mode.CBC)
+    override val keySize: DataItem<Int>
+        get() = value(1)
+    override val tagSize: DataItem<Int>
+        get() = value(1)
+
+
+}
+
+
+

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/jca-cipher.codyze.kts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/jca-cipher.codyze.kts
@@ -1,11 +1,13 @@
 @file:Import("bsi-tr-rules.codyze.kts")
 
+import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.BackendDataItem
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.DataItem
 import de.fraunhofer.aisec.codyze.specificationLanguages.coko.core.modelling.value
 
 class JCACipher {
     fun getInstance(transformation: Any, provider: Any? = null) = op {
-        "javax.crypto.Cipher.getInstance" {
+        // TODO: Change back to "javax.crypto.Cipher.getInstance" when CPG resolves names correctly
+        "Cipher.getInstance" {
             signature(transformation)
             signature(transformation, provider)
         }
@@ -58,30 +60,43 @@ class JCACipherImpl: Bsi_tr_rules_codyze.Cypher {
     val cipher = JCACipher()
 
     override val algo: DataItem<Bsi_tr_rules_codyze.Algorithm>
-        get() = cipher.getInstance(Wildcard, Wildcard).arguments[1] withTransformation { dataItem ->
-            val stringValue = dataItem.value as? String
-            if(dataItem.value == null)
-                TransformationResult.failure("Value of BackendDataItem is null.")
-            else if(stringValue == null) {
-                TransformationResult.failure("Value of BackendDataItem is not a string.")
-            }
-            else {
-                val (algo, _) = stringValue.partition { it == '/' }
-                val algoEnum = Bsi_tr_rules_codyze.Algorithm.values().firstOrNull {  it.name == algo.uppercase() }
-                if(algoEnum == null)
-                    TransformationResult.failure("Could not resolve the string value to an algorithm")
-                else
-                    TransformationResult.success(algoEnum)
+        get() = cipher.getInstance(Wildcard, Wildcard).arguments[0] withTransformation { dataItem ->
+            transformTransformationString(dataItem, 0, "an algorithm") { string ->
+                Bsi_tr_rules_codyze.Algorithm.entries.firstOrNull {  it.name == string.uppercase() }
             }
         }
     override val mode: DataItem<Bsi_tr_rules_codyze.Mode>
-        get() = value(Bsi_tr_rules_codyze.Mode.CBC)
+        get() = cipher.getInstance(Wildcard, Wildcard).arguments[0] withTransformation { dataItem ->
+            transformTransformationString(dataItem, 1, "a mode") { string ->
+                Bsi_tr_rules_codyze.Mode.entries.firstOrNull {  it.name == string.uppercase() }
+            }
+        }
     override val keySize: DataItem<Int>
         get() = value(1)
     override val tagSize: DataItem<Int>
         get() = value(1)
 
 
+    fun <E> transformTransformationString(
+        dataItem: BackendDataItem,
+        index: Int,
+        errorMessage: String,
+        stringToResult: (String) -> E?): TransformationResult<E, String> {
+        val stringValue = dataItem.value as? String
+        return if(dataItem.value == null)
+            TransformationResult.failure("Value of BackendDataItem is null.")
+        else if(stringValue == null) {
+            TransformationResult.failure("Value of BackendDataItem is not a string.")
+        }
+        else {
+            val string = stringValue.split('/')[index]
+            val result = stringToResult(string)
+            if(result == null)
+                TransformationResult.failure("Could not resolve the string value to $errorMessage")
+            else
+                TransformationResult.success(result)
+        }
+    }
 }
 
 

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/rpc.concepts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/rpc.concepts
@@ -1,0 +1,14 @@
+concept Request {}
+
+concept Validation {
+  op validate(obj)
+}
+
+//rule AlwaysValidate {
+//  var req: Request
+//  var v: Validation
+//
+//  when req::*() {
+//    call v::validate(req) before in function scope
+//  }
+//}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/some.concepts
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/resources/concept/some.concepts
@@ -1,0 +1,25 @@
+concept Logging {
+  op log = info | warn | error
+  op info(msg, args...)
+  op warn(msg, args...)
+  op error(msg, args...)
+}
+
+concept Database {
+  op init()
+  op insert(obj)
+}
+
+concept UserContext {
+  var user
+}
+
+//rule AuditLog {
+//  var db: Database
+//  var ctx: UserContext
+//  var log: Logging
+
+//  when db::insert(x) {
+//    call log::log(_, ctx) afterwards in function scope
+//  }
+//}


### PR DESCRIPTION
In some cases API calls generate values from configurations that are not part of the source code (such as configuration files). To ensure that subsequent code adheres to set requirements, it's necessary to code some kind of check.

This PoC evaluates these checks to ensure requirements are met and to reduce false-positives.