### PR TITLE
Fix Windows Paths in Coko Tests

### DIFF
--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScriptHostTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScriptHostTest.kt
@@ -20,7 +20,6 @@ import io.mockk.mockk
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
-import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.writeText
 import kotlin.script.experimental.api.valueOrThrow
 import kotlin.test.Test
@@ -80,7 +79,7 @@ class CokoScriptHostTest {
 
     @Test
     fun `test import annotation`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -92,7 +91,7 @@ class CokoScriptHostTest {
         assertDoesNotThrow {
             CokoExecutor.eval(
                 """
-                    @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
+                    @file:Import("$modelDefinitionFile")
 
                     class TestImpl: TestConcept {
                         override fun log(message: String) { }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScriptHostTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScriptHostTest.kt
@@ -79,7 +79,7 @@ class CokoScriptHostTest {
 
     @Test
     fun `test import annotation`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -88,10 +88,11 @@ class CokoScriptHostTest {
             """.trimIndent()
         )
 
+        val modelImport = modelDefinitionFile.toAbsoluteInvariant()
         assertDoesNotThrow {
             CokoExecutor.eval(
                 """
-                    @file:Import("$modelDefinitionFile")
+                    @file:Import("$modelImport")
 
                     class TestImpl: TestConcept {
                         override fun log(message: String) { }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScriptHostTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/CokoScriptHostTest.kt
@@ -20,6 +20,7 @@ import io.mockk.mockk
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.writeText
 import kotlin.script.experimental.api.valueOrThrow
 import kotlin.test.Test
@@ -91,7 +92,7 @@ class CokoScriptHostTest {
         assertDoesNotThrow {
             CokoExecutor.eval(
                 """
-                    @file:Import("${modelDefinitionFile.toAbsolutePath()}")
+                    @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
 
                     class TestImpl: TestConcept {
                         override fun log(message: String) { }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
@@ -64,14 +64,6 @@ class ConceptTranslationTest {
                 .getResource("concept/bsi-tr.concepts"),
         ).map { it.toURI().toPath() }
 
-        val cokoConfiguration =
-            CokoConfiguration(
-                goodFindings = true,
-                pedantic = false,
-                spec = specFiles,
-                disabledSpecRules = emptyList(),
-            )
-
         val backend = CokoCpgBackend(cpgConfiguration)
         val specEvaluator = CokoExecutor.compileScriptsIntoSpecEvaluator(backend, specFiles)
 
@@ -102,14 +94,6 @@ class ConceptTranslationTest {
             CokoCpgIntegrationTest::class.java.classLoader
                 .getResource("concept/some.concepts"),
         ).map { it.toURI().toPath() }
-
-        val cokoConfiguration =
-            CokoConfiguration(
-                goodFindings = true,
-                pedantic = false,
-                spec = specFiles,
-                disabledSpecRules = emptyList(),
-            )
 
         val backend = CokoCpgBackend(cpgConfiguration)
         val specEvaluator = CokoExecutor.compileScriptsIntoSpecEvaluator(backend, specFiles)

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ConceptTranslationTest.kt
@@ -22,7 +22,7 @@ import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
 import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
-import kotlin.io.path.Path
+import kotlin.io.path.toPath
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -34,7 +34,7 @@ class ConceptTranslationTest {
             .getResource("IntegrationTests/CokoCpg/Main.java"),
         CokoCpgIntegrationTest::class.java.classLoader
             .getResource("IntegrationTests/CokoCpg/SimpleOrder.java")
-    ).map { Path(it.path) }.also { assertEquals(2, it.size) }
+    ).map { it.toURI().toPath() }.also { assertEquals(2, it.size) }
 
     val cpgConfiguration =
         CPGConfiguration(
@@ -62,7 +62,7 @@ class ConceptTranslationTest {
         val specFiles = listOfNotNull(
             CokoCpgIntegrationTest::class.java.classLoader
                 .getResource("concept/bsi-tr.concepts"),
-        ).map { Path(it.path) }
+        ).map { it.toURI().toPath() }
 
         val cokoConfiguration =
             CokoConfiguration(
@@ -101,7 +101,7 @@ class ConceptTranslationTest {
         val specFiles = listOfNotNull(
             CokoCpgIntegrationTest::class.java.classLoader
                 .getResource("concept/some.concepts"),
-        ).map { Path(it.path) }
+        ).map { it.toURI().toPath() }
 
         val cokoConfiguration =
             CokoConfiguration(
@@ -148,7 +148,7 @@ class ConceptTranslationTest {
                 .getResource("concept/followedByImplementations.codyze.kts"),
             CokoCpgIntegrationTest::class.java.classLoader
                 .getResource("concept/followedByRule.codyze.kts"),
-        ).map { Path(it.path) }
+        ).map { it.toURI().toPath() }
 
         val cokoConfiguration =
             CokoConfiguration(

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ScriptAnalysisTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ScriptAnalysisTest.kt
@@ -21,7 +21,6 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host.CokoExecu
 import io.mockk.mockk
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
-import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.writeText
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.findAnnotation
@@ -88,7 +87,7 @@ class ScriptAnalysisTest {
 
     @Test
     fun `test import annotation`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -100,7 +99,7 @@ class ScriptAnalysisTest {
         val result =
             CokoExecutor.eval(
                 """
-                    @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
+                    @file:Import("$modelDefinitionFile")
 
                     class TestImpl: TestConcept {
                         override fun log(message: String) { }
@@ -114,7 +113,7 @@ class ScriptAnalysisTest {
 
     @Test
     fun `test multiple spec files`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -126,7 +125,7 @@ class ScriptAnalysisTest {
         val implementationFile = tempDir.resolve("implementation.codyze.kts")
         implementationFile.writeText(
             """
-                @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
+                @file:Import("$modelDefinitionFile")
     
                 class TestImpl: TestConcept {
                     override fun log(message: String) { }
@@ -146,7 +145,7 @@ class ScriptAnalysisTest {
 
     @Test
     fun `test rule annotation`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 @Rule("Some description")
@@ -169,7 +168,7 @@ class ScriptAnalysisTest {
     fun `test default imports, implicit receivers, import annotation and rule annotation at once`(
         @TempDir tempDir: Path
     ) {
-        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -181,7 +180,7 @@ class ScriptAnalysisTest {
         val implementationFile = tempDir.resolve("implementation.codyze.kts")
         implementationFile.writeText(
             """
-                @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
+                @file:Import("$modelDefinitionFile")
     
                 class TestImpl: TestConcept {
                     override fun log(message: String) = op {

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ScriptAnalysisTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ScriptAnalysisTest.kt
@@ -87,7 +87,7 @@ class ScriptAnalysisTest {
 
     @Test
     fun `test import annotation`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -96,10 +96,11 @@ class ScriptAnalysisTest {
             """.trimIndent()
         )
 
+        val modelImport = modelDefinitionFile.toAbsoluteInvariant()
         val result =
             CokoExecutor.eval(
                 """
-                    @file:Import("$modelDefinitionFile")
+                    @file:Import("$modelImport")
 
                     class TestImpl: TestConcept {
                         override fun log(message: String) { }
@@ -113,7 +114,7 @@ class ScriptAnalysisTest {
 
     @Test
     fun `test multiple spec files`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -123,9 +124,10 @@ class ScriptAnalysisTest {
         )
 
         val implementationFile = tempDir.resolve("implementation.codyze.kts")
+        val modelImport = modelDefinitionFile.toAbsoluteInvariant()
         implementationFile.writeText(
             """
-                @file:Import("$modelDefinitionFile")
+                @file:Import("$modelImport")
     
                 class TestImpl: TestConcept {
                     override fun log(message: String) { }
@@ -145,7 +147,7 @@ class ScriptAnalysisTest {
 
     @Test
     fun `test rule annotation`(@TempDir tempDir: Path) {
-        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 @Rule("Some description")
@@ -168,7 +170,7 @@ class ScriptAnalysisTest {
     fun `test default imports, implicit receivers, import annotation and rule annotation at once`(
         @TempDir tempDir: Path
     ) {
-        val modelDefinitionFile = tempDir.resolveAbsoluteInvariant("model.codyze.kts")
+        val modelDefinitionFile = tempDir.resolve("model.codyze.kts")
         modelDefinitionFile.writeText(
             """
                 interface TestConcept {
@@ -177,10 +179,11 @@ class ScriptAnalysisTest {
             """.trimIndent()
         )
 
+        val modelImport = modelDefinitionFile.toAbsoluteInvariant()
         val implementationFile = tempDir.resolve("implementation.codyze.kts")
         implementationFile.writeText(
             """
-                @file:Import("$modelDefinitionFile")
+                @file:Import("$modelImport")
     
                 class TestImpl: TestConcept {
                     override fun log(message: String) = op {

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ScriptAnalysisTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/ScriptAnalysisTest.kt
@@ -21,6 +21,7 @@ import de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl.host.CokoExecu
 import io.mockk.mockk
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.writeText
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.findAnnotation
@@ -99,7 +100,7 @@ class ScriptAnalysisTest {
         val result =
             CokoExecutor.eval(
                 """
-                    @file:Import("${modelDefinitionFile.toAbsolutePath()}")
+                    @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
 
                     class TestImpl: TestConcept {
                         override fun log(message: String) { }
@@ -125,7 +126,7 @@ class ScriptAnalysisTest {
         val implementationFile = tempDir.resolve("implementation.codyze.kts")
         implementationFile.writeText(
             """
-                @file:Import("${modelDefinitionFile.toAbsolutePath()}")
+                @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
     
                 class TestImpl: TestConcept {
                     override fun log(message: String) { }
@@ -180,7 +181,7 @@ class ScriptAnalysisTest {
         val implementationFile = tempDir.resolve("implementation.codyze.kts")
         implementationFile.writeText(
             """
-                @file:Import("${modelDefinitionFile.toAbsolutePath()}")
+                @file:Import("${modelDefinitionFile.toAbsolutePath().invariantSeparatorsPathString}")
     
                 class TestImpl: TestConcept {
                     override fun log(message: String) = op {

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/TestUtils.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/TestUtils.kt
@@ -1,16 +1,29 @@
+/*
+ * Copyright (c) 2024, Fraunhofer AISEC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
 
 import java.nio.file.Path
 import kotlin.io.path.invariantSeparatorsPathString
 
-
 /**
- *  Resolves any path as an absolute path that is system invariant.
+ *  Forces any path into an absolute path String that is system invariant.
  *
  *  This is especially important when testing with Windows, as paths with backward slashes are not allowed
  *  as Coko imports.
- *  @see java.nio.file.Path.resolve(String)
  */
-fun Path.resolveAbsoluteInvariant(other: String): Path {
-    return Path.of(this.resolve(other).toAbsolutePath().invariantSeparatorsPathString)
+fun Path.toAbsoluteInvariant(): String {
+    return this.toAbsolutePath().invariantSeparatorsPathString
 }

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/TestUtils.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/TestUtils.kt
@@ -1,0 +1,16 @@
+package de.fraunhofer.aisec.codyze.specificationLanguages.coko.dsl
+
+import java.nio.file.Path
+import kotlin.io.path.invariantSeparatorsPathString
+
+
+/**
+ *  Resolves any path as an absolute path that is system invariant.
+ *
+ *  This is especially important when testing with Windows, as paths with backward slashes are not allowed
+ *  as Coko imports.
+ *  @see java.nio.file.Path.resolve(String)
+ */
+fun Path.resolveAbsoluteInvariant(other: String): Path {
+    return Path.of(this.resolve(other).toAbsolutePath().invariantSeparatorsPathString)
+}

--- a/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/WheneverEvaluatorTest.kt
+++ b/codyze-specification-languages/coko/coko-dsl/src/test/kotlin/de/fraunhofer/aisec/codyze/specificationLanguages/coko/dsl/WheneverEvaluatorTest.kt
@@ -22,7 +22,7 @@ import de.fraunhofer.aisec.cpg.passes.EdgeCachePass
 import de.fraunhofer.aisec.cpg.passes.UnreachableEOGPass
 import io.github.detekt.sarif4k.ResultKind
 import org.junit.jupiter.api.Test
-import kotlin.io.path.Path
+import kotlin.io.path.toPath
 import kotlin.test.assertEquals
 
 // TODO: should probably in codyze-backends or coko-core
@@ -31,7 +31,7 @@ class WheneverEvaluatorTest {
     private val sourceFiles = listOfNotNull(
         CokoCpgIntegrationTest::class.java.classLoader
             .getResource("concept/CipherTestFile.java"),
-    ).map { Path(it.path) }.also { assertEquals(1, it.size) }
+    ).map { it.toURI().toPath() }.also { assertEquals(1, it.size) }
 
     val cpgConfiguration =
         CPGConfiguration(
@@ -64,7 +64,7 @@ class WheneverEvaluatorTest {
                 .getResource("concept/bsi-tr-rules.codyze.kts"),
             CokoCpgIntegrationTest::class.java.classLoader
                 .getResource("concept/jca-cipher.codyze.kts")
-        ).map { Path(it.path) }.also { assertEquals(2, it.size) }
+        ).map { it.toURI().toPath() }.also { assertEquals(2, it.size) }
 
         val cokoConfiguration =
             CokoConfiguration(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ cpg-language-java = { module = "de.fraunhofer.aisec:cpg-language-java", version.
 #cpg-analysis = { module = "com.github.Fraunhofer-AISEC.cpg:cpg-analysis", version.ref = "cpg"}
 #cpg-language-go = { module = "com.github.Fraunhofer-AISEC.cpg:cpg-language-go", version.ref = "cpg"}
 
-kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version = "6.0.4" }
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version = "6.0.9" }
 log4j-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version = "2.23.1"}
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "4.3.0"}
 koin = { module = "io.insert-koin:koin-core", version.ref = "koin"}


### PR DESCRIPTION
Complementing #836, this PR fixes more cases of the Path constructor being used on absolute windows paths.

Additionally, the import statement in Coko source code examples relies on invariant Path separators (forward slashes), which is now also properly applied.