### PR TITLE
Fix sporadic problems in test due to misaligned JUnit version

### DIFF
--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -16,7 +16,8 @@ dependencies {
 
     // Unit tests
     testImplementation(kotlin("test"))
-    testImplementation(libs.junit.params)
+    testImplementation(platform(libs.junit.bom)) // ensure aligned JUnit artifact version
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ kotlin-scripting-dependencies = { module = "org.jetbrains.kotlin:kotlin-scriptin
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt"}
 
 # test
-junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.10.2"}
+junit-bom = { module = "org.junit:junit-bom", version = "5.10.2" }
 mockk = { module = "io.mockk:mockk", version = "1.13.10"}
 
 # this is necessary for the plugins to be used in the buildSrc folder


### PR DESCRIPTION
Sometimes the tests fail due to AbstractMethod errors. The cause seems to be the use of JUnit params in a given version and using JUnit platform in another. This change:
* alignes JUnit version through the use of a platform declaration
* lets individual package version be aligned through the platform