### PR TITLE
Combine Future Kotlin Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,10 @@
     {
       "groupName": "PMD packages",
       "matchPackagePrefixes": ["net.sourceforge.pmd:pmd-"]
+    },
+    {
+      "groupName": "Kotlin version",
+      "matchPackagePrefixes": ["org.jetbrains.kotlin:kotlin-", "org.jetbrains.kotlin.plugin."]
     }
   ]
 }


### PR DESCRIPTION
This PR adds a new group to the renovate packageRules that matches the package prefixes `org.jetbrains.kotlin:kotlin-` and `org.jetbrains.kotlin.plugin.`.

This aims to prevent situations such as with #889 and #890 or also #866 and #867, where two independent PRs are made to update the main Kotlin packages and the serialization plugin, but both PRs contain identical changes anyways.